### PR TITLE
[Style]#7 메인 홈페이지 레이아웃 제작

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,17 @@
 import Banner from '@/components/features/home/Banner';
+import HospitalList from '@/components/features/home/HospitalList';
+import KaKaoMap from '@/components/features/home/KaKaoMap';
+import SearchBar from '@/components/features/home/SearchBar';
 
 export default function Home() {
   return (
-    <div className='w-full px-20'>
+    <div className='relative flex w-full flex-col items-center gap-20 px-20 text-xl'>
       <Banner />
+      <SearchBar />
+      <div className='flex w-full gap-10'>
+        <KaKaoMap />
+        <HospitalList />
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import SearchBar from '@/components/features/home/SearchBar';
 
 export default function Home() {
   return (
-    <div className='relative flex w-full flex-col items-center gap-20 px-20 text-xl'>
+    <div className='relative flex w-full flex-col items-center gap-20 px-20 pt-5 text-xl'>
       <Banner />
       <SearchBar />
       <div className='flex w-full gap-10'>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import Banner from '@/components/features/home/Banner';
 
 export default function Home() {
-  return <div>HOME</div>;
+  return (
+    <div className='w-full px-20'>
+      <Banner />
+    </div>
+  );
 }

--- a/src/components/common/HospitalCard.tsx
+++ b/src/components/common/HospitalCard.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { PATH } from '@/constants/routerPath';
+import { Button } from '../ui/button';
+
+const HospitalCard = () => {
+  //임의로 설정해둔 병원 아이디입니다
+  const hospitalId = '123';
+
+  return (
+    <div className='flex min-h-[120px] flex-col gap-2 rounded-xl border-2 border-main bg-white p-6'>
+      <div className='flex flex-col gap-1'>
+        <h1 className='text-lg font-bold'>이지은이비인후과</h1>
+        <h1 className='text-sm'>이비인후과</h1>
+      </div>
+      <div className='flex justify-end'>
+        <Link href={`${PATH.RESERVE}/${hospitalId}`}>
+          <Button>예약하기</Button>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default HospitalCard;

--- a/src/components/common/HospitalCard.tsx
+++ b/src/components/common/HospitalCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { PATH } from '@/constants/routerPath';
 import { Button } from '../ui/button';
@@ -13,9 +15,9 @@ const HospitalCard = () => {
         <h1 className='text-sm'>이비인후과</h1>
       </div>
       <div className='flex justify-end'>
-        <Link href={`${PATH.RESERVE}/${hospitalId}`}>
-          <Button>예약하기</Button>
-        </Link>
+        <Button asChild>
+          <Link href={`${PATH.RESERVE}/${hospitalId}`}>예약하기</Link>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/features/home/Banner.tsx
+++ b/src/components/features/home/Banner.tsx
@@ -1,0 +1,12 @@
+const Banner = () => {
+  return (
+    <div className='flex min-h-[280px] w-full flex-col gap-4 rounded-xl bg-sub p-20'>
+      <h1 className='text-4xl font-bold text-deep-blue'>
+        원하는 병원을 클릭 한 번으로
+      </h1>
+      <p className='text-xl'>지금 바로 내가 원하는 병원을 찾고 예약해보세요.</p>
+    </div>
+  );
+};
+
+export default Banner;

--- a/src/components/features/home/HospitalList.tsx
+++ b/src/components/features/home/HospitalList.tsx
@@ -1,0 +1,16 @@
+import HospitalCard from '@/components/common/HospitalCard';
+
+const HospitalList = () => {
+  // 실제 데이터 적용되면 HospitalCard는 map으로 돌릴 예정입니다.
+
+  return (
+    <div className='border-gray-03 flex flex-[1] flex-col gap-4 border-2 bg-white p-6'>
+      <h1 className='text-xl font-bold'>병원 목록</h1>
+      <HospitalCard />
+      <HospitalCard />
+      <HospitalCard />
+    </div>
+  );
+};
+
+export default HospitalList;

--- a/src/components/features/home/KaKaoMap.tsx
+++ b/src/components/features/home/KaKaoMap.tsx
@@ -1,0 +1,5 @@
+const KaKaoMap = () => {
+  return <div className='flex-[2] bg-gray02'>KaKaoMap</div>;
+};
+
+export default KaKaoMap;

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+
+const SearchBar = () => {
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <Input
+      className='absolute top-64 min-h-[60px] w-[900px] rounded-full border-gray03 bg-white text-xl'
+      placeholder='진료 보실 과목을 입력해주세요.'
+      value={inputValue}
+      onChange={(e) => setInputValue(e.target.value)}
+    />
+  );
+};
+
+export default SearchBar;

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -8,7 +8,7 @@ const SearchBar = () => {
 
   return (
     <Input
-      className='absolute top-64 min-h-[60px] w-[900px] rounded-full border-gray03 bg-white text-xl'
+      className='absolute top-64 min-h-[60px] w-[900px] rounded-full border-gray03 bg-white px-6 text-xl'
       placeholder='진료 보실 과목을 입력해주세요.'
       value={inputValue}
       onChange={(e) => setInputValue(e.target.value)}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,13 +9,13 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-main text-primary-foreground shadow hover:bg-main-hover',
+        default: 'bg-main text-primary-foreground hover:bg-main-hover',
         destructive:
-          'bg-red text-destructive-foreground shadow-sm hover:bg-destructive/90',
+          'bg-red text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}


### PR DESCRIPTION
## ✨ style(#7): 메인 홈페이지 레이아웃 제작

<br/>

## 🔎 작업 내용
✅ 메인 홈페이지의 전반적인 레이아웃을 제작하였습니다.
카카오 지도와 실제 데이터(supase)는 이후에 넣을 예정입니다.
✅ Button 컴포넌트에 그림자가 들어가있길래 모두 지워놨습니다.

지금 캡쳐된 화면을 보니깐 검색창 위치가 되게 애매하네요?!
이 부분은 수정해보겠습니다

📌 Button with asChild
한 가지 정보를 남기고 가자면,
Button(공통 컴포넌트)에서 asChild를 붙이고 안에 다른 태그를 넣으면, button 태그가 아닌 넣은 태그로 반영됩니다!
Button이랑 똑같은 스타일인데 Link 태그로 사용하고 싶을 때 이용하시면 좋을 것 같아요~
(with 지은님&챗지피티)

<br/>

## 🖼️ 작업 내용 미리보기
<img width="1916" alt="스크린샷 2025-03-21 오후 9 39 30" src="https://github.com/user-attachments/assets/dd4f8445-b998-4afb-b232-28b570ff994a" />

<br/>

## 💬 리뷰 요구사항
레이아웃에서 수정됐으면 좋겠는 부분이 있으면 말씀해주세요~!

## ⏰ 예상 리뷰 시간
5분

### ✔️ 이슈 닫기
Closes #7 
