### PR TITLE
[Feature]#13 text title 공통 컴포넌트 구현

### DIFF
--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -50,9 +50,7 @@ const Text = ({ size, margin, align, color, children }: TextProps) => {
 
   const alignStyles: string = `text-${align}`;
 
-  const baseStyles: string = 'justify-items-center';
-
-  const styles = `${baseStyles} ${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
+  const styles = `${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
   return <p className={styles}>{children}</p>;
 };
 

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -1,0 +1,59 @@
+import { TitleProps } from './Title';
+/**
+ * 텍스트 컴포넌트입니다. <p> 태그로 기본 설정되어있습니다.
+ *
+ * @example
+ * <Text size='md' margin='md' align='center' color='main'>
+ *   본문 컴포넌트입니다.
+ * </Text>
+ *
+ * @component
+ * @prop {size} [size] - 글자 크기 ('xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl')
+ * @prop {margin} [margin] - 마진 크기 ('sm' | 'md' | 'lg')
+ * @prop {align} [align] - 정렬 위치 ('left' | 'center' | 'right')
+ * @prop {color} [color] - 색상 ('main' | 'main-hover' | 'sub' | 'sub-hover' | 'black01' | 'black02' | 'gray01' | 'gray02' | 'gray03' | 'red' | 'deep-blue')
+ */
+
+type TextProps = Omit<TitleProps, 'tag'>;
+
+const Text = ({ size, margin, align, color, children }: TextProps) => {
+  const sizeStyles: Record<TextProps['size'], string> = {
+    xs: 'text-xs',
+    sm: 'text-xs lg:text-sm',
+    md: 'text-sm lg:text-md',
+    lg: 'text-md lg:text-lg',
+    xl: 'text-md md:text-lg lg:text-xl',
+    '2xl': 'text-lg md:text-xl lg:text-2xl',
+    '3xl': 'text-xl md:text-2xl lg:text-3xl',
+    '4xl': 'text-2xl md:text-3xl lg:text-4xl',
+  };
+
+  const marginStyles: Record<NonNullable<TitleProps['margin']>, string> = {
+    sm: 'm-1 lg:m-2',
+    md: 'm-2 md:m-3 lg:m-4',
+    lg: 'm-4 md:m-5 lg:m-6',
+  };
+
+  const colorStyles: Record<TitleProps['color'], string> = {
+    main: 'text-main',
+    'main-hover': 'text-main-hover',
+    sub: 'text-sub',
+    'sub-hover': 'text-hover',
+    black01: 'text-black01',
+    black02: 'text-black02',
+    gray01: 'text-gray01',
+    gray02: 'text-gray02',
+    gray03: 'text-gray03',
+    red: 'text-red',
+    'deep-blue': 'text-deep-blue',
+  };
+
+  const alignStyles: string = `text-${align}`;
+
+  const baseStyles: string = 'justify-items-center';
+
+  const styles = `${baseStyles} ${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
+  return <p className={styles}>{children}</p>;
+};
+
+export default Text;

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -3,20 +3,19 @@ import { TitleProps } from './Title';
  * 텍스트 컴포넌트입니다. <p> 태그로 기본 설정되어있습니다.
  *
  * @example
- * <Text size='md' margin='md' align='center' color='main'>
+ * <Text size='md' align='center' color='main'>
  *   본문 컴포넌트입니다.
  * </Text>
  *
  * @component
  * @prop {size} [size] - 글자 크기 ('xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl')
- * @prop {margin} [margin] - 마진 크기 ('sm' | 'md' | 'lg')
  * @prop {align} [align] - 정렬 위치 ('left' | 'center' | 'right')
  * @prop {color} [color] - 색상 ('main' | 'main-hover' | 'sub' | 'sub-hover' | 'black01' | 'black02' | 'gray01' | 'gray02' | 'gray03' | 'red' | 'deep-blue')
  */
 
 type TextProps = Omit<TitleProps, 'tag'>;
 
-const Text = ({ size, margin, align, color, children }: TextProps) => {
+const Text = ({ size, align, color, children }: TextProps) => {
   const sizeStyles: Record<TextProps['size'], string> = {
     xs: 'text-xs',
     sm: 'text-xs lg:text-sm',
@@ -26,12 +25,6 @@ const Text = ({ size, margin, align, color, children }: TextProps) => {
     '2xl': 'text-lg md:text-xl lg:text-2xl',
     '3xl': 'text-xl md:text-2xl lg:text-3xl',
     '4xl': 'text-2xl md:text-3xl lg:text-4xl',
-  };
-
-  const marginStyles: Record<NonNullable<TitleProps['margin']>, string> = {
-    sm: 'm-1 lg:m-2',
-    md: 'm-2 md:m-3 lg:m-4',
-    lg: 'm-4 md:m-5 lg:m-6',
   };
 
   const colorStyles: Record<TitleProps['color'], string> = {
@@ -50,7 +43,7 @@ const Text = ({ size, margin, align, color, children }: TextProps) => {
 
   const alignStyles: string = `text-${align}`;
 
-  const styles = `${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
+  const styles = `${sizeStyles[size]} ${colorStyles[color]} ${alignStyles}`;
   return <p className={styles}>{children}</p>;
 };
 

--- a/src/components/ui/Title.tsx
+++ b/src/components/ui/Title.tsx
@@ -2,7 +2,7 @@
  * 제목 컴포넌트입니다. font-bold 속성이 기본 설정되어 있습니다.
  *
  * @example
- * <Title tag='h1' size='xl' margin='md' align='center' color='main'>
+ * <Title tag='h1' size='xl' align='center' color='main'>
  *   제목 컴포넌트입니다.
  * </Title>
  *
@@ -10,7 +10,6 @@
  *
  * @prop {tag} tag - 태그 종류  ('h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6')
  * @prop {size} [size] - 글자 크기 ('xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl')
- * @prop {margin} [margin] - 마진 크기 ('sm' | 'md' | 'lg')
  * @prop {align} [align] - 정렬 위치 ('left' | 'center' | 'right')
  * @prop {color} [color] - 색상 ('main' | 'main-hover' | 'sub' | 'sub-hover' | 'black01' | 'black02' | 'gray01' | 'gray02' | 'gray03' | 'red' | 'deep-blue')
  */
@@ -19,7 +18,6 @@ export interface TitleProps {
   children: React.ReactNode;
   tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
-  margin?: 'sm' | 'md' | 'lg';
   align: 'left' | 'center' | 'right';
   color:
     | 'main'
@@ -35,7 +33,7 @@ export interface TitleProps {
     | 'deep-blue';
 }
 
-const Title = ({ tag, size, margin, align, color, children }: TitleProps) => {
+const Title = ({ tag, size, align, color, children }: TitleProps) => {
   const Tag = tag;
 
   const sizeStyles: Record<TitleProps['size'], string> = {
@@ -47,12 +45,6 @@ const Title = ({ tag, size, margin, align, color, children }: TitleProps) => {
     '2xl': 'text-3xl md:text-4xl lg:text-5xl',
     '3xl': 'text-4xl md:text-5xl lg:text-6xl',
     '4xl': 'text-5xl md:6xl lg:text-7xl',
-  };
-
-  const marginStyles: Record<NonNullable<TitleProps['margin']>, string> = {
-    sm: 'm-1 lg:m-2',
-    md: 'm-2 md:m-3 lg:m-4',
-    lg: 'm-4 md:m-5 lg:m-6',
   };
 
   const colorStyles: Record<TitleProps['color'], string> = {
@@ -73,7 +65,7 @@ const Title = ({ tag, size, margin, align, color, children }: TitleProps) => {
 
   const baseStyles: string = 'font-bold';
 
-  const styles: string = `${baseStyles} ${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
+  const styles: string = `${baseStyles} ${sizeStyles[size]} ${colorStyles[color]} ${alignStyles}`;
 
   return <Tag className={styles}>{children}</Tag>;
 };

--- a/src/components/ui/Title.tsx
+++ b/src/components/ui/Title.tsx
@@ -71,7 +71,7 @@ const Title = ({ tag, size, margin, align, color, children }: TitleProps) => {
 
   const alignStyles: string = `text-${align}`;
 
-  const baseStyles: string = 'font-bold justify-items-center';
+  const baseStyles: string = 'font-bold';
 
   const styles: string = `${baseStyles} ${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
 

--- a/src/components/ui/Title.tsx
+++ b/src/components/ui/Title.tsx
@@ -1,0 +1,81 @@
+/**
+ * 제목 컴포넌트입니다. font-bold 속성이 기본 설정되어 있습니다.
+ *
+ * @example
+ * <Title tag='h1' size='xl' margin='md' align='center' color='main'>
+ *   제목 컴포넌트입니다.
+ * </Title>
+ *
+ * @component
+ *
+ * @prop {tag} tag - 태그 종류  ('h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6')
+ * @prop {size} [size] - 글자 크기 ('xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl')
+ * @prop {margin} [margin] - 마진 크기 ('sm' | 'md' | 'lg')
+ * @prop {align} [align] - 정렬 위치 ('left' | 'center' | 'right')
+ * @prop {color} [color] - 색상 ('main' | 'main-hover' | 'sub' | 'sub-hover' | 'black01' | 'black02' | 'gray01' | 'gray02' | 'gray03' | 'red' | 'deep-blue')
+ */
+
+export interface TitleProps {
+  children: React.ReactNode;
+  tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+  margin?: 'sm' | 'md' | 'lg';
+  align: 'left' | 'center' | 'right';
+  color:
+    | 'main'
+    | 'main-hover'
+    | 'sub'
+    | 'sub-hover'
+    | 'black01'
+    | 'black02'
+    | 'gray01'
+    | 'gray02'
+    | 'gray03'
+    | 'red'
+    | 'deep-blue';
+}
+
+const Title = ({ tag, size, margin, align, color, children }: TitleProps) => {
+  const Tag = tag;
+
+  const sizeStyles: Record<TitleProps['size'], string> = {
+    xs: 'text-sm md:text-md lg:text-lg',
+    sm: 'text-md md:text-lg lg:text-xl',
+    md: 'text-lg md:text-xl lg:text-2xl',
+    lg: 'text-xl md:text-2xl lg:text-3xl',
+    xl: 'text-2xl md:text-3xl lg:text-4xl',
+    '2xl': 'text-3xl md:text-4xl lg:text-5xl',
+    '3xl': 'text-4xl md:text-5xl lg:text-6xl',
+    '4xl': 'text-5xl md:6xl lg:text-7xl',
+  };
+
+  const marginStyles: Record<NonNullable<TitleProps['margin']>, string> = {
+    sm: 'm-1 lg:m-2',
+    md: 'm-2 md:m-3 lg:m-4',
+    lg: 'm-4 md:m-5 lg:m-6',
+  };
+
+  const colorStyles: Record<TitleProps['color'], string> = {
+    main: 'text-main',
+    'main-hover': 'text-main-hover',
+    sub: 'text-sub',
+    'sub-hover': 'text-hover',
+    black01: 'text-black01',
+    black02: 'text-black02',
+    gray01: 'text-gray01',
+    gray02: 'text-gray02',
+    gray03: 'text-gray03',
+    red: 'text-red',
+    'deep-blue': 'text-deep-blue',
+  };
+
+  const alignStyles: string = `text-${align}`;
+
+  const baseStyles: string = 'font-bold justify-items-center';
+
+  const styles: string = `${baseStyles} ${sizeStyles[size]} ${margin ? marginStyles[margin] : ''} ${colorStyles[color]} ${alignStyles}`;
+
+  return <Tag className={styles}>{children}</Tag>;
+};
+
+export default Title;


### PR DESCRIPTION
## ✨ feature(#13): text title 공통 컴포넌트 구현

<br/>

## 🔎 작업 내용

- 제목과 본문 재사용 컴포넌트를 구현했습니다.

  <br/>

## 🖼️ 작업 내용 미리보기

<img width="516" alt="스크린샷 2025-03-22 02 30 37" src="https://github.com/user-attachments/assets/a10aa94a-90d9-4cb4-96bc-cc43da1df974" />


<br/>

## 💬 리뷰 요구사항

아까도 언급했었지만, margin 값을 어떻게 하는 것이 좋을까요? 전체 4면, 상, 하, 좌, 우 모두를 제가 작성한 것처럼 반응형을 고려해서 스타일을 지정하면 코드가 상당히 길어지고 가독성이 떨어질 것 같은 생각이 듭니다.(같은 코드가 5번 반복되어야 해서...) 
1. 여백이 필요할 땐 div로 값싸서 부모 태그에 margin이나 padding을 주는 방법이 있을 것 같습니다.
2. 반응형을 고려하지 않는다면  속성 (xs, sm 등)에 값을 매핑하는 방식의 코드가 가능할 것 같습니다. 이렇게 되면 코드가 약간은 간결해질 수 있을 것 같아요.
```
const marginMap = {
  xs: '1',
  sm: '2',
};
``` 
이런식으로요!
3. 아니면 저희가 px 값을 허용하고 있으니 프롭스 자체를 `10px`이런식으로 받는 방법도 있습니다. 그러나 이렇게 되면 제가 장점이라고 언급했던 크기에 대한 공통화의 제어가 풀리긴 합니다..ㅠㅠ
```
`m-${number}`
```
위와 같은 형태에서 number를 props로 받는 것입니다.

그리고 이 부분을 생각하다보니 또 의견을 얻을 부분이 있는데, 폰트 사이즈도 px 단위로 통일 하는 것이 좋을까요? 지금은 tailwind 기본 사이즈라 rem 단위로 되어있습니다. 
(완벽하지 않은 pr로 많은 것을 고려하게 만들어 죄송하군요.ㅠㅠ)

## ⏰ 예상 리뷰 시간

10분

### ✔️ 이슈 닫기

Closes #13  // 해당 이슈에 대한 작업이 완전히 끝난 경우