### PR TITLE
[Style]#32 my page 예약 상세보기 레이아웃

### DIFF
--- a/src/app/(auth)/mypage/page.tsx
+++ b/src/app/(auth)/mypage/page.tsx
@@ -1,7 +1,9 @@
 import MyPageContainer from '@/components/features/mypage/MyPageContainer';
 import MyPageContentsContainer from '@/components/features/mypage/MyPageContentsContainer';
-import MyReserveCalendar from '@/components/features/mypage/MyReserveCalendar/MyReserveCalendar';
 import SideBar from '@/components/features/mypage/sideBar/SideBar';
+import { Button } from '@/components/ui/button';
+import Text from '@/components/ui/Text';
+import Title from '@/components/ui/Title';
 
 const MyPage = () => {
   const userData = {
@@ -13,7 +15,68 @@ const MyPage = () => {
     <MyPageContainer>
       <SideBar user={userData} />
       <MyPageContentsContainer>
-        <MyReserveCalendar />
+        {/* <MyReserveCalendar /> */}
+        <div className='relative flex h-[216px] w-full flex-col gap-5 rounded-[16px] bg-sub p-8'>
+          <Title tag='h1' size='lg' align='left' color='deep-blue'>
+            서울통정형외과의원 잠실점
+          </Title>
+          <Text size='lg' align='left' color='black02'>
+            2025년 3월 20일 (목) 14:00
+          </Text>
+          <Text size='lg' align='left' color='black02'>
+            상태: 예약 확정
+          </Text>
+          <div className='absolute bottom-8 right-8 flex gap-10'>
+            <Button className='h-[44px] w-[146px] rounded-[10px] bg-deep-blue font-bold'>
+              예약 변경
+            </Button>
+            <Button className='h-[44px] w-[146px] rounded-[10px] font-bold'>
+              예약 취소
+            </Button>
+            <Button className='h-[44px] w-[146px] rounded-[10px] border-2 border-deep-blue bg-white font-bold text-deep-blue'>
+              병원 상세
+            </Button>
+          </div>
+        </div>
+        <div className='flex gap-20'>
+          {/* 예약 정보: 남은 공간을 채움 */}
+          <div className='h-[356px] flex-1 rounded-[15px] border-2 border-gray03'>
+            <div className='flex h-[90px] rounded-[13px] bg-main-hover'>
+              <h2 className='my-auto ml-10 text-3xl font-bold text-white'>
+                예약 정보
+              </h2>
+            </div>
+            <div className='grid grid-cols-2 gap-8 p-8'>
+              <div className='flex flex-col gap-3'>
+                <Title tag='h3' size='md' align='left' color='black02'>
+                  예약자
+                </Title>
+                <Text size='lg' align='left' color='black02'>
+                  {userData.name}님
+                </Text>
+              </div>
+              <div className='flex flex-col gap-3'>
+                <Title tag='h3' size='md' align='left' color='black02'>
+                  진료과
+                </Title>
+                <Text size='lg' align='left' color='black02'>
+                  정형외과
+                </Text>
+              </div>
+              <div className='col-span-2 flex flex-col gap-3'>
+                <Title tag='h3' size='md' align='left' color='black02'>
+                  증상
+                </Title>
+                <Text size='lg' align='left' color='black02'>
+                  다리가 후들거려요
+                </Text>
+              </div>
+            </div>
+          </div>
+          <div className='mr-20 h-[356px] w-[356px] flex-shrink-0 bg-gray03'>
+            지도 들어갈 곳
+          </div>
+        </div>
       </MyPageContentsContainer>
     </MyPageContainer>
   );

--- a/src/app/(auth)/mypage/page.tsx
+++ b/src/app/(auth)/mypage/page.tsx
@@ -1,9 +1,7 @@
 import MyPageContainer from '@/components/features/mypage/MyPageContainer';
 import MyPageContentsContainer from '@/components/features/mypage/MyPageContentsContainer';
+import MyReserveDetail from '@/components/features/mypage/MyReserveDetail/MyReserveDetail';
 import SideBar from '@/components/features/mypage/sideBar/SideBar';
-import { Button } from '@/components/ui/button';
-import Text from '@/components/ui/Text';
-import Title from '@/components/ui/Title';
 
 const MyPage = () => {
   const userData = {
@@ -16,67 +14,7 @@ const MyPage = () => {
       <SideBar user={userData} />
       <MyPageContentsContainer>
         {/* <MyReserveCalendar /> */}
-        <div className='relative flex h-[216px] w-full flex-col gap-5 rounded-[16px] bg-sub p-8'>
-          <Title tag='h1' size='lg' align='left' color='deep-blue'>
-            서울통정형외과의원 잠실점
-          </Title>
-          <Text size='lg' align='left' color='black02'>
-            2025년 3월 20일 (목) 14:00
-          </Text>
-          <Text size='lg' align='left' color='black02'>
-            상태: 예약 확정
-          </Text>
-          <div className='absolute bottom-8 right-8 flex gap-10'>
-            <Button className='h-[44px] w-[146px] rounded-[10px] bg-deep-blue font-bold'>
-              예약 변경
-            </Button>
-            <Button className='h-[44px] w-[146px] rounded-[10px] font-bold'>
-              예약 취소
-            </Button>
-            <Button className='h-[44px] w-[146px] rounded-[10px] border-2 border-deep-blue bg-white font-bold text-deep-blue'>
-              병원 상세
-            </Button>
-          </div>
-        </div>
-        <div className='flex gap-20'>
-          {/* 예약 정보: 남은 공간을 채움 */}
-          <div className='h-[356px] flex-1 rounded-[15px] border-2 border-gray03'>
-            <div className='flex h-[90px] rounded-[13px] bg-main-hover'>
-              <h2 className='my-auto ml-10 text-3xl font-bold text-white'>
-                예약 정보
-              </h2>
-            </div>
-            <div className='grid grid-cols-2 gap-8 p-8'>
-              <div className='flex flex-col gap-3'>
-                <Title tag='h3' size='md' align='left' color='black02'>
-                  예약자
-                </Title>
-                <Text size='lg' align='left' color='black02'>
-                  {userData.name}님
-                </Text>
-              </div>
-              <div className='flex flex-col gap-3'>
-                <Title tag='h3' size='md' align='left' color='black02'>
-                  진료과
-                </Title>
-                <Text size='lg' align='left' color='black02'>
-                  정형외과
-                </Text>
-              </div>
-              <div className='col-span-2 flex flex-col gap-3'>
-                <Title tag='h3' size='md' align='left' color='black02'>
-                  증상
-                </Title>
-                <Text size='lg' align='left' color='black02'>
-                  다리가 후들거려요
-                </Text>
-              </div>
-            </div>
-          </div>
-          <div className='mr-20 h-[356px] w-[356px] flex-shrink-0 bg-gray03'>
-            지도 들어갈 곳
-          </div>
-        </div>
+        <MyReserveDetail />
       </MyPageContentsContainer>
     </MyPageContainer>
   );

--- a/src/components/features/mypage/MyReserveDetail/Banner/Banner.tsx
+++ b/src/components/features/mypage/MyReserveDetail/Banner/Banner.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@/components/ui/button';
+import Text from '@/components/ui/Text';
+import Title from '@/components/ui/Title';
+import BannerContainer from './BannerContainer';
+
+const Banner = () => {
+  return (
+    <BannerContainer>
+      <Title tag='h1' size='lg' align='left' color='deep-blue'>
+        서울통정형외과의원 잠실점
+      </Title>
+      <Text size='lg' align='left' color='black02'>
+        2025년 3월 20일 (목) 14:00
+      </Text>
+      <Text size='lg' align='left' color='black02'>
+        상태: 예약 확정
+      </Text>
+      <div className='absolute bottom-8 right-8 flex gap-10'>
+        <Button className='h-[44px] w-[146px] rounded-[10px] bg-deep-blue font-bold'>
+          예약 변경
+        </Button>
+        <Button className='h-[44px] w-[146px] rounded-[10px] font-bold'>
+          예약 취소
+        </Button>
+        <Button className='h-[44px] w-[146px] rounded-[10px] border-2 border-deep-blue bg-white font-bold text-deep-blue'>
+          병원 상세
+        </Button>
+      </div>
+    </BannerContainer>
+  );
+};
+
+export default Banner;

--- a/src/components/features/mypage/MyReserveDetail/Banner/Banner.tsx
+++ b/src/components/features/mypage/MyReserveDetail/Banner/Banner.tsx
@@ -22,7 +22,7 @@ const Banner = () => {
         <Button className='h-[44px] w-[146px] rounded-[10px] font-bold'>
           예약 취소
         </Button>
-        <Button className='h-[44px] w-[146px] rounded-[10px] border-2 border-deep-blue bg-white font-bold text-deep-blue'>
+        <Button className='h-[44px] w-[146px] rounded-[10px] border-2 border-deep-blue bg-white font-bold text-deep-blue hover:bg-gray02'>
           병원 상세
         </Button>
       </div>

--- a/src/components/features/mypage/MyReserveDetail/Banner/BannerContainer.tsx
+++ b/src/components/features/mypage/MyReserveDetail/Banner/BannerContainer.tsx
@@ -1,0 +1,9 @@
+const BannerContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className='relative flex h-[216px] w-full flex-col gap-5 rounded-[16px] bg-sub p-8'>
+      {children}
+    </div>
+  );
+};
+
+export default BannerContainer;

--- a/src/components/features/mypage/MyReserveDetail/MyReserveDetail.tsx
+++ b/src/components/features/mypage/MyReserveDetail/MyReserveDetail.tsx
@@ -1,0 +1,13 @@
+import Banner from './Banner/Banner';
+import ReserveContents from './ReserveContents/ReserveContents';
+
+const MyReserveDetail = () => {
+  return (
+    <>
+      <Banner />
+      <ReserveContents />
+    </>
+  );
+};
+
+export default MyReserveDetail;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/ContentsContainer.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/ContentsContainer.tsx
@@ -1,0 +1,5 @@
+const ContentsContainer = ({ children }: { children: React.ReactNode }) => {
+  return <div className='flex gap-20'>{children}</div>;
+};
+
+export default ContentsContainer;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoContainer.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoContainer.tsx
@@ -1,0 +1,9 @@
+const InfoContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className='h-[356px] flex-1 rounded-[15px] border-2 border-gray03'>
+      {children}
+    </div>
+  );
+};
+
+export default InfoContainer;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoDetailContainer.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoDetailContainer.tsx
@@ -1,0 +1,5 @@
+const InfoDetailContainer = ({ children }: { children: React.ReactNode }) => {
+  return <div className='relative grid grid-cols-2 gap-8 p-8'>{children}</div>;
+};
+
+export default InfoDetailContainer;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoDetailContents.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoDetailContents.tsx
@@ -1,0 +1,22 @@
+import Text from '@/components/ui/Text';
+import Title from '@/components/ui/Title';
+
+interface DetailContents {
+  title: string;
+  text: string;
+}
+
+const InfoDetailContents = ({ title, text }: DetailContents) => {
+  return (
+    <div className='flex flex-col gap-3'>
+      <Title tag='h3' size='md' align='left' color='black02'>
+        {title}
+      </Title>
+      <Text size='lg' align='left' color='black02'>
+        {text}님
+      </Text>
+    </div>
+  );
+};
+
+export default InfoDetailContents;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoDetailContents.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoDetailContents.tsx
@@ -13,7 +13,7 @@ const InfoDetailContents = ({ title, text }: DetailContents) => {
         {title}
       </Title>
       <Text size='lg' align='left' color='black02'>
-        {text}님
+        {text}
       </Text>
     </div>
   );

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoMap.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoMap.tsx
@@ -1,0 +1,9 @@
+const InfoMap = () => {
+  return (
+    <div className='mr-20 h-[356px] w-[356px] flex-shrink-0 bg-gray03'>
+      지도 들어갈 곳
+    </div>
+  );
+};
+
+export default InfoMap;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoTitleBox.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/InfoTitleBox.tsx
@@ -1,0 +1,9 @@
+const InfoTitleBox = () => {
+  return (
+    <div className='flex h-[90px] rounded-[13px] bg-main-hover'>
+      <h2 className='my-auto ml-10 text-3xl font-bold text-white'>예약 정보</h2>
+    </div>
+  );
+};
+
+export default InfoTitleBox;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/ReserveContents.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/ReserveContents.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/ui/button';
+import ContentsContainer from './ContentsContainer';
+import InfoContainer from './InfoContainer';
+import InfoDetailContainer from './InfoDetailContainer';
+import InfoDetailContents from './InfoDetailContents';
+import InfoMap from './InfoMap';
+import InfoTitleBox from './InfoTitleBox';
+
+const ReserveContents = () => {
+  return (
+    <ContentsContainer>
+      <InfoContainer>
+        <InfoTitleBox />
+        <InfoDetailContainer>
+          <InfoDetailContents title='예약자' text='김수임' />
+          <InfoDetailContents title='진료과' text='정형외과' />
+          <InfoDetailContents title='증상' text='다리가 후들거려요.' />
+          <Button className='absolute bottom-0 right-8 h-[44px] w-[146px] rounded-[10px] font-bold'>
+            리뷰 작성
+          </Button>{' '}
+          {/*날짜가 지나면 해당 버튼이 나타나도록*/}
+        </InfoDetailContainer>
+      </InfoContainer>
+      <InfoMap />
+    </ContentsContainer>
+  );
+};
+
+export default ReserveContents;

--- a/src/components/features/mypage/MyReserveDetail/ReserveContents/ReserveContents.tsx
+++ b/src/components/features/mypage/MyReserveDetail/ReserveContents/ReserveContents.tsx
@@ -12,12 +12,12 @@ const ReserveContents = () => {
       <InfoContainer>
         <InfoTitleBox />
         <InfoDetailContainer>
-          <InfoDetailContents title='예약자' text='김수임' />
+          <InfoDetailContents title='예약자' text='김수임님' />
           <InfoDetailContents title='진료과' text='정형외과' />
           <InfoDetailContents title='증상' text='다리가 후들거려요.' />
           <Button className='absolute bottom-0 right-8 h-[44px] w-[146px] rounded-[10px] font-bold'>
             리뷰 작성
-          </Button>{' '}
+          </Button>
           {/*날짜가 지나면 해당 버튼이 나타나도록*/}
         </InfoDetailContainer>
       </InfoContainer>


### PR DESCRIPTION
## ✨ style(#32 ): my page 예약 상세보기 레이아웃

<br/>

## 🔎 작업 내용

- 나의 예약 상세보기 ui 를 구현했습니다.
- 피그마 상의 수정하기 버튼이 배너의 버튼과 기능이 겹치게 되는 것 같아 리뷰작성 버튼으로 변경했습니다.
- 예약일이 지나면 해당 버튼이 나타나도록 하고, 리뷰 작성 창이 예약 정보 컴포넌트에 렌더링 되도록 구현할 예정입니다.

  <br/>

## 🖼️ 작업 내용 미리보기

<img width="1927" alt="스크린샷 2025-03-23 02 53 32" src="https://github.com/user-attachments/assets/810dfefa-8dd0-4b5f-a0de-7d76a83d89a4" />


<br/>

## 💬 리뷰 요구사항

- 슬랙 디엠으로도 남겼는데 제 코드 개성이 너무 튄다면 적절히 수정하려 합니다! 편히 말씀해주세요.
- 예약 변경 버튼을 눌러서 연결되는 창은 예약 정보가 기입된 상태의 기존 예약하기 창으로 이동하는 게 좋을까요? 아니면 별도의 수정페이지를 만드는 게 좋을까요?

## ⏰ 예상 리뷰 시간

10분

### ✔️ 이슈 닫기

Closes #32 
