### PR TITLE
[Feature]#52 메인 홈페이지 - 병원 검색 기능 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.words": [
     "appkey",
     "clusterer",
+    "ilike",
     "Kakao",
     "MEDICLCIK",
     "MEDICLICK",

--- a/src/components/common/HospitalCard.tsx
+++ b/src/components/common/HospitalCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { PATH } from '@/constants/routerPath';
 import { Tables } from '@/types/supabase';
+import { useHospitalStore } from '@/utils/zustand/useHospitalStore';
 import { Button } from '../ui/button';
 import Text from '../ui/Text';
 import Title from '../ui/Title';
@@ -12,8 +13,17 @@ interface HospitalCardProps {
 }
 
 const HospitalCard = ({ hospital }: HospitalCardProps) => {
+  const setSelectedHospital = useHospitalStore(
+    (state) => state.setSelectedHospital,
+  );
+
   return (
-    <div className='flex flex-col gap-2 rounded-xl border-2 border-main bg-white p-6 hover:bg-gray02'>
+    <div
+      className='flex flex-col gap-2 rounded-xl border-2 border-main bg-white p-6 hover:bg-gray02'
+      onClick={() =>
+        setSelectedHospital({ lat: hospital.lat, lng: hospital.lng })
+      }
+    >
       <div className='flex flex-col gap-1'>
         <Title>{hospital.name}</Title>
         <Text>{hospital.department}</Text>

--- a/src/components/common/HospitalCard.tsx
+++ b/src/components/common/HospitalCard.tsx
@@ -13,7 +13,7 @@ interface HospitalCardProps {
 
 const HospitalCard = ({ hospital }: HospitalCardProps) => {
   return (
-    <div className='flex flex-col gap-2 rounded-xl border-2 border-main bg-white p-6'>
+    <div className='flex flex-col gap-2 rounded-xl border-2 border-main bg-white p-6 hover:bg-gray02'>
       <div className='flex flex-col gap-1'>
         <Title>{hospital.name}</Title>
         <Text>{hospital.department}</Text>

--- a/src/components/common/HospitalCard.tsx
+++ b/src/components/common/HospitalCard.tsx
@@ -30,7 +30,12 @@ const HospitalCard = ({ hospital }: HospitalCardProps) => {
       </div>
       <div className='flex justify-end'>
         <Button asChild>
-          <Link href={`${PATH.RESERVE}/${hospital.id}`}>예약하기</Link>
+          <Link
+            href={`${PATH.RESERVE}/${hospital.id}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            예약하기
+          </Link>
         </Button>
       </div>
     </div>

--- a/src/components/features/home/CustomOverlay.tsx
+++ b/src/components/features/home/CustomOverlay.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import Title from '@/components/ui/Title';
+import { PATH } from '@/constants/routerPath';
+
+interface CustomOverlayProps {
+  name: string;
+  id: string;
+}
+
+const CustomOverlay = ({ name, id }: CustomOverlayProps) => {
+  return (
+    <div className='flex min-h-[120px] w-[180px] flex-col items-center justify-center gap-3 px-2 py-3'>
+      <Title align='center'>{name}</Title>
+      <Button asChild>
+        <Link href={`${PATH.HOSPITAL}/${id}`}>더보기</Link>
+      </Button>
+    </div>
+  );
+};
+
+export default CustomOverlay;

--- a/src/components/features/home/EventMarkerContainer.tsx
+++ b/src/components/features/home/EventMarkerContainer.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { MapMarker } from 'react-kakao-maps-sdk';
+import { Button } from '@/components/ui/button';
+import Title from '@/components/ui/Title';
+import { PATH } from '@/constants/routerPath';
+import { Location } from '@/types/map';
+
+interface EventMarkerContainerProps {
+  position: Location;
+}
+
+const EventMarkerContainer = ({ position }: EventMarkerContainerProps) => {
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const { lat, lng, name, id } = position;
+
+  return (
+    <MapMarker
+      position={{ lat, lng }}
+      onClick={() => setIsInfoOpen((prev) => !prev)}
+    >
+      {isInfoOpen && (
+        <div className='flex h-[100px] w-[150px] flex-col items-center justify-center gap-2'>
+          <Title>{name}</Title>
+          <Button asChild>
+            <Link href={`${PATH.HOSPITAL}/${id}`}>더보기</Link>
+          </Button>
+        </div>
+      )}
+    </MapMarker>
+  );
+};
+
+export default EventMarkerContainer;

--- a/src/components/features/home/EventMarkerContainer.tsx
+++ b/src/components/features/home/EventMarkerContainer.tsx
@@ -1,22 +1,27 @@
 'use client';
 
-import { useState } from 'react';
 import { MapMarker } from 'react-kakao-maps-sdk';
 import { Location } from '@/types/map';
 import CustomOverlay from './CustomOverlay';
 
 interface EventMarkerContainerProps {
   position: Location;
+  activeMarkerId: string | null;
+  setActiveMarkerId: (id: string | null) => void;
 }
 
-const EventMarkerContainer = ({ position }: EventMarkerContainerProps) => {
-  const [isInfoOpen, setIsInfoOpen] = useState(false);
+const EventMarkerContainer = ({
+  position,
+  activeMarkerId,
+  setActiveMarkerId,
+}: EventMarkerContainerProps) => {
   const { lat, lng, name, id } = position;
+  const isInfoOpen = activeMarkerId === id;
 
   return (
     <MapMarker
       position={{ lat, lng }}
-      onClick={() => setIsInfoOpen((prev) => !prev)}
+      onClick={() => setActiveMarkerId(isInfoOpen ? null : id)}
     >
       {isInfoOpen && <CustomOverlay name={name} id={id} />}
     </MapMarker>

--- a/src/components/features/home/EventMarkerContainer.tsx
+++ b/src/components/features/home/EventMarkerContainer.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { useState } from 'react';
 import { MapMarker } from 'react-kakao-maps-sdk';
-import { Button } from '@/components/ui/button';
-import Title from '@/components/ui/Title';
-import { PATH } from '@/constants/routerPath';
 import { Location } from '@/types/map';
+import CustomOverlay from './CustomOverlay';
 
 interface EventMarkerContainerProps {
   position: Location;
@@ -21,14 +18,7 @@ const EventMarkerContainer = ({ position }: EventMarkerContainerProps) => {
       position={{ lat, lng }}
       onClick={() => setIsInfoOpen((prev) => !prev)}
     >
-      {isInfoOpen && (
-        <div className='flex h-[100px] w-[150px] flex-col items-center justify-center gap-2'>
-          <Title>{name}</Title>
-          <Button asChild>
-            <Link href={`${PATH.HOSPITAL}/${id}`}>더보기</Link>
-          </Button>
-        </div>
-      )}
+      {isInfoOpen && <CustomOverlay name={name} id={id} />}
     </MapMarker>
   );
 };

--- a/src/components/features/home/HospitalList.tsx
+++ b/src/components/features/home/HospitalList.tsx
@@ -2,6 +2,7 @@
 
 import HospitalCard from '@/components/common/HospitalCard';
 import Loading from '@/components/common/Loading';
+import Text from '@/components/ui/Text';
 import Title from '@/components/ui/Title';
 import { useHospitalInView } from '@/hooks/tanstackQuery/useHospitalInView';
 import { useHospitalsInfiniteQuery } from '@/hooks/tanstackQuery/useHospitalsInfiniteQuery';
@@ -21,22 +22,32 @@ const HospitalList = () => {
     fetchNextPage,
   });
 
-  if (status === 'pending') return <Loading size={100} />;
+  if (status === 'pending')
+    return (
+      <div className='flex-[1]'>
+        <Loading size={100} />
+      </div>
+    );
   if (status === 'error')
     return (
-      <div className='flex items-center justify-center'>
-        병원 목록을 불러오는데 오류가 발생하였습니다.
+      <div className='flex flex-[1] items-center justify-center'>
+        <Text>병원 목록을 불러오는데 오류가 발생하였습니다.</Text>
       </div>
     );
 
   return (
-    <div className='border-gray-03 flex max-h-[750px] min-h-[350px] flex-[1] flex-col gap-4 overflow-y-auto border-2 bg-white p-6'>
+    <div className='border-gray-03 flex max-h-[750px] min-h-[400px] flex-[1] flex-col gap-4 overflow-y-auto border-2 bg-white p-6'>
       <Title>병원 목록</Title>
-      {hospitalList?.pages.map((page) =>
-        page.map((hospital) => {
-          return <HospitalCard key={hospital.id} hospital={hospital} />;
-        }),
+      {!hospitalList || hospitalList.pages.flat().length === 0 ? (
+        <Text>검색하신 병원이 존재하지 않습니다.</Text>
+      ) : (
+        hospitalList.pages.map((page) =>
+          page.map((hospital) => (
+            <HospitalCard key={hospital.id} hospital={hospital} />
+          )),
+        )
       )}
+
       <div ref={ref}></div>
     </div>
   );

--- a/src/components/features/home/HospitalList.tsx
+++ b/src/components/features/home/HospitalList.tsx
@@ -24,13 +24,13 @@ const HospitalList = () => {
 
   if (status === 'pending')
     return (
-      <div className='flex-[1]'>
+      <div className='flex-[1] border-2 p-6'>
         <Loading size={100} />
       </div>
     );
   if (status === 'error')
     return (
-      <div className='flex flex-[1] items-center justify-center'>
+      <div className='flex flex-[1] items-center justify-center border-2 p-6'>
         <Text>병원 목록을 불러오는데 오류가 발생하였습니다.</Text>
       </div>
     );

--- a/src/components/features/home/HospitalList.tsx
+++ b/src/components/features/home/HospitalList.tsx
@@ -6,6 +6,7 @@ import Text from '@/components/ui/Text';
 import Title from '@/components/ui/Title';
 import { useHospitalInView } from '@/hooks/tanstackQuery/useHospitalInView';
 import { useHospitalsInfiniteQuery } from '@/hooks/tanstackQuery/useHospitalsInfiniteQuery';
+import { checkEmptyPages } from '@/utils/func/checkEmptyPages';
 
 const HospitalList = () => {
   const {
@@ -38,7 +39,7 @@ const HospitalList = () => {
   return (
     <div className='border-gray-03 flex max-h-[750px] min-h-[400px] flex-[1] flex-col gap-4 overflow-y-auto border-2 bg-white p-6'>
       <Title>병원 목록</Title>
-      {!hospitalList || hospitalList.pages.flat().length === 0 ? (
+      {!hospitalList || checkEmptyPages(hospitalList) ? (
         <Text>검색하신 병원이 존재하지 않습니다.</Text>
       ) : (
         hospitalList.pages.map((page) =>

--- a/src/components/features/home/KaKaoMap.tsx
+++ b/src/components/features/home/KaKaoMap.tsx
@@ -1,20 +1,29 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Map } from 'react-kakao-maps-sdk';
 import Loading from '@/components/common/Loading';
 import Text from '@/components/ui/Text';
 import { useAllHospitalLocation } from '@/hooks/map/useAllHospitalLocation';
 import { useCurrentLocation } from '@/hooks/map/useCurrentLocation';
 import { useKakaoLoad } from '@/hooks/map/useKakaoLoad';
+import { useHospitalStore } from '@/utils/zustand/useHospitalStore';
 import EventMarkerContainer from './EventMarkerContainer';
 
 const KaKaoMap = () => {
   const currentLocation = useCurrentLocation();
   const hospitalLocationList = useAllHospitalLocation();
+  const selectedHospital = useHospitalStore((state) => state.selectedHospital);
 
+  const [mapCenter, setMapCenter] = useState(currentLocation);
   const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null);
   const [loading, error] = useKakaoLoad();
+
+  useEffect(() => {
+    if (selectedHospital) {
+      setMapCenter(selectedHospital);
+    }
+  }, [selectedHospital]);
 
   if (loading)
     return (
@@ -32,11 +41,7 @@ const KaKaoMap = () => {
 
   return (
     <div className='relative w-full flex-[2] border-2'>
-      <Map
-        center={currentLocation}
-        level={3}
-        className='h-[300px] md:h-[750px]'
-      >
+      <Map center={mapCenter} level={3} className='h-[300px] md:h-[750px]'>
         {hospitalLocationList.map((position) => (
           <EventMarkerContainer
             key={position.id}

--- a/src/components/features/home/KaKaoMap.tsx
+++ b/src/components/features/home/KaKaoMap.tsx
@@ -2,6 +2,7 @@
 
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import Loading from '@/components/common/Loading';
+import Text from '@/components/ui/Text';
 import { useAllHospitalLocation } from '@/hooks/map/useAllHospitalLocation';
 import { useCurrentLocation } from '@/hooks/map/useCurrentLocation';
 import { useKakaoLoad } from '@/hooks/map/useKakaoLoad';
@@ -14,15 +15,15 @@ const KaKaoMap = () => {
 
   if (loading)
     return (
-      <div className='flex-[2]'>
+      <div className='h-[300px] flex-[2] border-2 md:h-[750px]'>
         <Loading size={180} />
       </div>
     );
 
   if (error)
     return (
-      <div className='flex flex-[2] items-center justify-center'>
-        지도를 불러오는데 오류가 발생하였습니다.
+      <div className='flex h-[300px] flex-[2] items-center justify-center border-2 md:h-[750px]'>
+        <Text>지도를 불러오는데 오류가 발생하였습니다.</Text>
       </div>
     );
 
@@ -31,7 +32,7 @@ const KaKaoMap = () => {
       <Map
         center={currentLocation}
         level={3}
-        className='h-[300px] w-full md:h-full'
+        className='h-[300px] md:h-[750px]'
       >
         {hospitalLocationList.map((position, idx) => {
           return <MapMarker key={idx} position={position} />;

--- a/src/components/features/home/KaKaoMap.tsx
+++ b/src/components/features/home/KaKaoMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Map } from 'react-kakao-maps-sdk';
 import Loading from '@/components/common/Loading';
 import Text from '@/components/ui/Text';
@@ -12,6 +13,7 @@ const KaKaoMap = () => {
   const currentLocation = useCurrentLocation();
   const hospitalLocationList = useAllHospitalLocation();
 
+  const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null);
   const [loading, error] = useKakaoLoad();
 
   if (loading)
@@ -36,7 +38,12 @@ const KaKaoMap = () => {
         className='h-[300px] md:h-[750px]'
       >
         {hospitalLocationList.map((position) => (
-          <EventMarkerContainer key={position.id} position={position} />
+          <EventMarkerContainer
+            key={position.id}
+            position={position}
+            activeMarkerId={activeMarkerId}
+            setActiveMarkerId={setActiveMarkerId}
+          />
         ))}
       </Map>
     </div>

--- a/src/components/features/home/KaKaoMap.tsx
+++ b/src/components/features/home/KaKaoMap.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import { Map } from 'react-kakao-maps-sdk';
 import Loading from '@/components/common/Loading';
 import Text from '@/components/ui/Text';
 import { useAllHospitalLocation } from '@/hooks/map/useAllHospitalLocation';
 import { useCurrentLocation } from '@/hooks/map/useCurrentLocation';
 import { useKakaoLoad } from '@/hooks/map/useKakaoLoad';
+import EventMarkerContainer from './EventMarkerContainer';
 
 const KaKaoMap = () => {
   const currentLocation = useCurrentLocation();
@@ -34,9 +35,9 @@ const KaKaoMap = () => {
         level={3}
         className='h-[300px] md:h-[750px]'
       >
-        {hospitalLocationList.map((position, idx) => {
-          return <MapMarker key={idx} position={position} />;
-        })}
+        {hospitalLocationList.map((position) => (
+          <EventMarkerContainer key={position.id} position={position} />
+        ))}
       </Map>
     </div>
   );

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -8,7 +8,7 @@ import { useSearchStore } from '@/utils/zustand/useSearchStore';
 
 const SearchBar = () => {
   const DEBOUNCE_DELAY = 400;
-  const { searchKeyword, setSearchKeyword } = useSearchStore();
+  const { searchKeyword, setSearchKeyword } = useSearchStore((state) => state);
 
   const debouncedSearch = useCallback(
     debounce(setSearchKeyword, DEBOUNCE_DELAY),

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,23 +1,28 @@
 'use client';
 
 import { debounce } from 'lodash';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';
 import { useSearchStore } from '@/utils/zustand/useSearchStore';
 
 const SearchBar = () => {
   const DEBOUNCE_DELAY = 400;
-  const { searchKeyword, setSearchKeyword } = useSearchStore((state) => state);
+  const [inputValue, setInputValue] = useState('');
+  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+
+    const filteredKeyword = e.target.value.replace(/[^가-힣a-zA-Z0-9]/g, '');
+    setSearchKeyword(filteredKeyword);
+    debouncedSearch(filteredKeyword);
+  };
 
   const debouncedSearch = useCallback(
     debounce(setSearchKeyword, DEBOUNCE_DELAY),
     [],
   );
-
-  useEffect(() => {
-    debouncedSearch(searchKeyword);
-  }, [searchKeyword, debouncedSearch]);
 
   return (
     <div className='relative w-full max-w-[800px]'>
@@ -26,8 +31,8 @@ const SearchBar = () => {
         type='text'
         className='min-h-[60px] rounded-full border-2 border-gray03 bg-white pl-6 pr-14 text-lg'
         placeholder='원하는 병원을 찾아보세요.'
-        value={searchKeyword}
-        onChange={(e) => setSearchKeyword(e.target.value)}
+        value={inputValue}
+        onChange={handleChange}
       />
     </div>
   );

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -18,9 +18,7 @@ const SearchBar = () => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
-
     const filteredKeyword = e.target.value.replace(/[^가-힣a-zA-Z0-9]/g, '');
-    setSearchKeyword(filteredKeyword);
     debouncedSearch(filteredKeyword);
   };
 

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -11,8 +11,9 @@ const SearchBar = () => {
     <div className='relative w-full max-w-[800px]'>
       <IoSearch className='text-gray0 absolute right-4 top-1/2 -translate-y-1/2 text-3xl text-gray-400' />
       <Input
-        className='min-h-[60px] rounded-full border-2 border-gray03 bg-white px-6 text-lg'
-        placeholder='진료 보실 과목을 입력해주세요.'
+        type='text'
+        className='min-h-[60px] rounded-full border-2 border-gray03 bg-white pl-6 pr-14 text-lg'
+        placeholder='어떤 병원을 예약하실건가요?'
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
       />

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,23 +1,28 @@
 'use client';
 
 import { debounce } from 'lodash';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';
 import { useSearchStore } from '@/utils/zustand/useSearchStore';
 
 const SearchBar = () => {
   const DEBOUNCE_DELAY = 400;
-  const { searchKeyword, setSearchKeyword } = useSearchStore((state) => state);
+  const [inputValue, setInputValue] = useState('');
+  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
 
   const debouncedSearch = useCallback(
     debounce(setSearchKeyword, DEBOUNCE_DELAY),
     [],
   );
 
-  useEffect(() => {
-    debouncedSearch(searchKeyword);
-  }, [searchKeyword, debouncedSearch]);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+
+    const filteredKeyword = e.target.value.replace(/[^가-힣a-zA-Z0-9]/g, '');
+    setSearchKeyword(filteredKeyword);
+    debouncedSearch(filteredKeyword);
+  };
 
   return (
     <div className='relative w-full max-w-[800px]'>
@@ -26,8 +31,8 @@ const SearchBar = () => {
         type='text'
         className='min-h-[60px] rounded-full border-2 border-gray03 bg-white pl-6 pr-14 text-lg'
         placeholder='원하는 병원을 찾아보세요.'
-        value={searchKeyword}
-        onChange={(e) => setSearchKeyword(e.target.value)}
+        value={inputValue}
+        onChange={handleChange}
       />
     </div>
   );

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useState } from 'react';
+import { IoSearch } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';
 
 const SearchBar = () => {
   const [inputValue, setInputValue] = useState('');
 
   return (
-    <Input
-      className='min-h-[60px] max-w-[800px] rounded-full border-gray03 bg-white px-6 text-lg'
-      placeholder='진료 보실 과목을 입력해주세요.'
-      value={inputValue}
-      onChange={(e) => setInputValue(e.target.value)}
-    />
+    <div className='relative w-full max-w-[800px]'>
+      <IoSearch className='text-gray0 absolute right-4 top-1/2 -translate-y-1/2 text-3xl text-gray-400' />
+      <Input
+        className='min-h-[60px] rounded-full border-2 border-gray03 bg-white px-6 text-lg'
+        placeholder='진료 보실 과목을 입력해주세요.'
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+      />
+    </div>
   );
 };
 

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,11 +1,23 @@
 'use client';
 
-import { useState } from 'react';
+import { debounce } from 'lodash';
+import { useCallback, useEffect } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';
+import { useSearchStore } from '@/utils/zustand/useSearchStore';
 
 const SearchBar = () => {
-  const [inputValue, setInputValue] = useState('');
+  const DEBOUNCE_DELAY = 400;
+  const { searchKeyword, setSearchKeyword } = useSearchStore();
+
+  const debouncedSearch = useCallback(
+    debounce(setSearchKeyword, DEBOUNCE_DELAY),
+    [],
+  );
+
+  useEffect(() => {
+    debouncedSearch(searchKeyword);
+  }, [searchKeyword, debouncedSearch]);
 
   return (
     <div className='relative w-full max-w-[800px]'>
@@ -13,9 +25,9 @@ const SearchBar = () => {
       <Input
         type='text'
         className='min-h-[60px] rounded-full border-2 border-gray03 bg-white pl-6 pr-14 text-lg'
-        placeholder='어떤 병원을 예약하실건가요?'
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
+        placeholder='원하는 병원을 찾아보세요.'
+        value={searchKeyword}
+        onChange={(e) => setSearchKeyword(e.target.value)}
       />
     </div>
   );

--- a/src/hooks/map/useCurrentLocation.ts
+++ b/src/hooks/map/useCurrentLocation.ts
@@ -7,8 +7,8 @@ import { Location } from '@/types/map';
  */
 export const useCurrentLocation = () => {
   const [currentLocation, setCurrentLocation] = useState<Location>({
-    lat: 33.450701,
-    lng: 126.570667,
+    lat: 33.4996213,
+    lng: 126.5311884,
   });
 
   useEffect(() => {

--- a/src/hooks/map/useCurrentLocation.ts
+++ b/src/hooks/map/useCurrentLocation.ts
@@ -6,7 +6,9 @@ import { Location } from '@/types/map';
  * @returns currentLocation - 사용자의 현재 위도, 경도
  */
 export const useCurrentLocation = () => {
-  const [currentLocation, setCurrentLocation] = useState<Location>({
+  const [currentLocation, setCurrentLocation] = useState<
+    Omit<Location, 'name' | 'id'>
+  >({
     lat: 33.4996213,
     lng: 126.5311884,
   });

--- a/src/hooks/tanstackQuery/useHospitalsInfiniteQuery.ts
+++ b/src/hooks/tanstackQuery/useHospitalsInfiniteQuery.ts
@@ -11,7 +11,7 @@ import { useSearchStore } from '@/utils/zustand/useSearchStore';
 export const useHospitalsInfiniteQuery = () => {
   const HOSPITAL_PAGE_SIZE = 10;
 
-  const { searchKeyword } = useSearchStore();
+  const searchKeyword = useSearchStore((state) => state.searchKeyword);
 
   return useInfiniteQuery({
     queryKey: [QUERY_KEY.HOSPITAL, searchKeyword],

--- a/src/hooks/tanstackQuery/useHospitalsInfiniteQuery.ts
+++ b/src/hooks/tanstackQuery/useHospitalsInfiniteQuery.ts
@@ -1,8 +1,8 @@
 'use client';
-
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { getAllHospitalData } from '@/utils/api/hospitals';
+import { useSearchStore } from '@/utils/zustand/useSearchStore';
 
 /**
  * 병원 목록을 10개 단위로 무한 스크롤할 수 있게 해주는 훅
@@ -11,9 +11,12 @@ import { getAllHospitalData } from '@/utils/api/hospitals';
 export const useHospitalsInfiniteQuery = () => {
   const HOSPITAL_PAGE_SIZE = 10;
 
+  const { searchKeyword } = useSearchStore();
+
   return useInfiniteQuery({
-    queryKey: [QUERY_KEY.HOSPITAL],
-    queryFn: ({ pageParam = 1 }) => getAllHospitalData(pageParam),
+    queryKey: [QUERY_KEY.HOSPITAL, searchKeyword],
+    queryFn: ({ pageParam = 1 }) =>
+      getAllHospitalData(pageParam, searchKeyword),
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => {
       return lastPage?.length === HOSPITAL_PAGE_SIZE

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,4 +1,6 @@
 export interface Location {
+  id: string;
   lat: number;
   lng: number;
+  name: string;
 }

--- a/src/utils/api/hospitals.ts
+++ b/src/utils/api/hospitals.ts
@@ -4,7 +4,7 @@ import { Tables } from '@/types/supabase';
 import { supabase } from '../supabase/supabase';
 
 /**
- * 모든 병원의 위치(위도, 경도, 이름)를 반환하는 함수
+ * 모든 병원의 위치(위도, 경도, 이름, id)를 반환하는 함수
  * @returns allHospitalLocations - 모든 병원의 위치(위도, 경도) 정보
  */
 export const getAllHospitalLocation = async () => {

--- a/src/utils/api/hospitals.ts
+++ b/src/utils/api/hospitals.ts
@@ -42,16 +42,22 @@ export const getAllHospitalLocation = async () => {
  */
 export const getAllHospitalData = async (
   pageParam: number,
+  searchKeyword: string,
 ): Promise<Tables<'hospitals'>[]> => {
   try {
     const pageSize = 10;
     const start = (pageParam - 1) * pageSize;
     const end = start + pageSize - 1;
 
-    const { data: hospitalData, error } = await supabase
-      .from(TABLE.HOSPITALS)
-      .select('*')
-      .range(start, end);
+    let query = supabase.from(TABLE.HOSPITALS).select('*');
+
+    // 검색창에 키워드가 입력되면, 해당 키워드를 가진 병원 목록을 찾음
+    if (searchKeyword) {
+      query = query.ilike('name', `%${searchKeyword}%`);
+    }
+
+    // 검색창에 키워드가 없으면, 전체 병원 목록을 반환함
+    const { data: hospitalData, error } = await query.range(start, end);
 
     if (error) throw error;
 

--- a/src/utils/api/hospitals.ts
+++ b/src/utils/api/hospitals.ts
@@ -53,7 +53,7 @@ export const getAllHospitalData = async (
 
     // 검색창에 키워드가 입력되면, 해당 키워드를 가진 병원 목록을 찾음
     if (searchKeyword) {
-      query = query.ilike('name', `%${searchKeyword}%`);
+      query = query.ilike('normalized_name', `%${searchKeyword}%`);
     }
 
     // 검색창에 키워드가 없으면, 전체 병원 목록을 반환함

--- a/src/utils/api/hospitals.ts
+++ b/src/utils/api/hospitals.ts
@@ -4,7 +4,7 @@ import { Tables } from '@/types/supabase';
 import { supabase } from '../supabase/supabase';
 
 /**
- * 모든 병원의 위치(위도, 경도)를 반환하는 함수
+ * 모든 병원의 위치(위도, 경도, 이름)를 반환하는 함수
  * @returns allHospitalLocations - 모든 병원의 위치(위도, 경도) 정보
  */
 export const getAllHospitalLocation = async () => {
@@ -19,7 +19,7 @@ export const getAllHospitalLocation = async () => {
 
       const { data, error } = await supabase
         .from(TABLE.HOSPITALS)
-        .select('lat, lng')
+        .select('lat, lng, name, id')
         .range(start, end);
 
       if (error) throw error;
@@ -37,7 +37,7 @@ export const getAllHospitalLocation = async () => {
 
 /**
  * 모든 병원의 정보를 페이지 단위로 10개씩 반환하는 함수
- * 무한스크롤 기능을 위한 코드입니다
+ * 무한스크롤 기능을 위한 코드
  * @returns allHospitalData - 모든 병원의 기본 정보
  */
 export const getAllHospitalData = async (

--- a/src/utils/func/checkEmptyPages.ts
+++ b/src/utils/func/checkEmptyPages.ts
@@ -1,0 +1,8 @@
+import { InfiniteData } from '@tanstack/react-query';
+import { Tables } from '@/types/supabase';
+
+export const checkEmptyPages = (
+  hospitalList: InfiniteData<Tables<'hospitals'>[]>,
+): boolean => {
+  return hospitalList.pages.flat().length === 0;
+};

--- a/src/utils/zustand/useHospitalStore.ts
+++ b/src/utils/zustand/useHospitalStore.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+interface HospitalStore {
+  selectedHospital: { lat: number; lng: number } | null;
+  setSelectedHospital: (hospitalLocation: { lat: number; lng: number }) => void;
+}
+
+export const useHospitalStore = create<HospitalStore>((set) => ({
+  selectedHospital: null,
+  setSelectedHospital: (hospitalLocation) =>
+    set({ selectedHospital: hospitalLocation }),
+}));

--- a/src/utils/zustand/useSearchStore.ts
+++ b/src/utils/zustand/useSearchStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface SearchState {
+  searchKeyword: string;
+  setSearchKeyword: (term: string) => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  searchKeyword: '',
+  setSearchKeyword: (keyword) => set({ searchKeyword: keyword }),
+}));


### PR DESCRIPTION
## ✨ feature(#52): 메인 홈페이지 - 병원 검색 기능 구현

<br/>

## 🔎 작업 내용
✅ 병원 검색 기능을 구현했습니다.
✅ 지도에서 마커를 클릭하면 병원 상세 페이지로 넘어가는 오버레이가 뜹니다.
✅ 병원 목록을 클릭하면 지도에서 해당 병원의 위치를 보여줍니다.
✅ 카카오 맵 컴포넌트와 병원 리스트 컴포넌트가 벙렬로 위치하여, 검색 키워드와 선택한 병원 목록 위치를 zustand로 관리하였습니다.

<br/>

## 🖼️ 작업 내용 미리보기
https://github.com/user-attachments/assets/3cc836b8-fba5-4f3f-88c7-f1a8f1fc50ed

<br/>

## 💬 리뷰 요구사항
1. 병원 목록을 클릭했을 때 주변 마커가 많을 경우, 어떤 게 선택한 병원인지 알기 어렵더라고요. 병원 목록을 클릭했을 때 지도를 확대할 수 있는지 한 번 시도해보겠습니다.
2. useCallback을 적용한 부분이 잘 동작하지 않고 있습니다. 이 부분은 이후에 수정해보도록 하겠습니다.

## ⏰ 예상 리뷰 시간
5분~10분

### ✔️ 이슈 닫기
Closes #52 
