### PR TITLE
[Bugfix]#64 debounce에 useCallback이 적용되지 않는 문제 해결 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.5.2",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "lucide-react": "^0.483.0",
     "next": "14.2.18",
     "prettier-plugin-tailwindcss": "^0.6.11",
@@ -44,7 +44,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.16",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       embla-carousel-react:
         specifier: ^8.5.2
         version: 8.5.2(react@18.3.1)
-      lodash:
+      lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
       lucide-react:
@@ -93,9 +93,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@18.3.19)(react@18.3.1)
     devDependencies:
-      '@types/lodash':
-        specifier: ^4.17.16
-        version: 4.17.16
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/node':
         specifier: ^20
         version: 20.17.25
@@ -689,6 +689,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
 
   '@types/lodash@4.17.16':
     resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
@@ -1722,11 +1725,11 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -3089,6 +3092,10 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.16
+
   '@types/lodash@4.17.16': {}
 
   '@types/node@20.17.25':
@@ -4304,9 +4311,9 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.merge@4.6.2: {}
+  lodash-es@4.17.21: {}
 
-  lodash@4.17.21: {}
+  lodash.merge@4.6.2: {}
 
   log-update@6.1.0:
     dependencies:

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,25 +1,29 @@
 'use client';
 
 import { debounce } from 'lodash-es';
-import { useCallback, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';
 import { useSearchStore } from '@/utils/zustand/useSearchStore';
 
 const SearchBar = () => {
   const DEBOUNCE_DELAY = 400;
+
   const [inputValue, setInputValue] = useState('');
   const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
 
-  const debouncedSearch = useCallback(
-    debounce(setSearchKeyword, DEBOUNCE_DELAY),
-    [],
+  const debouncedSetSearchKeyword = useMemo(
+    () =>
+      debounce((keyword: string) => {
+        setSearchKeyword(keyword);
+      }, DEBOUNCE_DELAY),
+    [setSearchKeyword],
   );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
     const filteredKeyword = e.target.value.replace(/[^가-힣a-zA-Z0-9]/g, '');
-    debouncedSearch(filteredKeyword);
+    debouncedSetSearchKeyword(filteredKeyword);
   };
 
   return (

--- a/src/components/features/home/SearchBar.tsx
+++ b/src/components/features/home/SearchBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { useCallback, useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';


### PR DESCRIPTION
## ✨ Bugfix(#64 ): debounce에 useCallback이 적용되지 않는 문제 해결 완료

<br/>

## 🔎 작업 내용
debounce 함수가 리렌더링 될 때마다 새롭게 생성되지 않기 위해 useCallback 사용했었는데 잘 적용이 되지 않는 문제가 있었습니다.
✅useMemo를 통해 캐싱된 결과를 반환하는 로직으로 수정하였습니다.

⭐️⭐️ lodash를 삭제하고 lodash-es로 다시 설치하였습니다. pull 받으시고 `pnpm install`해주시면 됩니다!
lodash-es로 설치한 이유: 필요한 함수만 받아올 수 있어서 용량이 줄어듭니다.

<br/>

## 🖼️ 작업 내용 미리보기
❌

<br/>

## 💬 리뷰 요구사항
더 좋은 방법이 있다면 말씀해주세요~!

## ⏰ 예상 리뷰 시간
3분

### ✔️ 이슈 닫기

Closes #64
