### PR TITLE
[Style]#59 예약 페이지 스타일 정리

### DIFF
--- a/src/app/(reservation)/reserve/[id]/page.tsx
+++ b/src/app/(reservation)/reserve/[id]/page.tsx
@@ -50,6 +50,7 @@ const ReservePage = ({ params }: Params) => {
       timePage={({ history }) => (
         <TimeFunnel
           operationTime={data?.operationTime}
+          id={params.id}
           onNext={() => history.push('submitPage')}
           onPrev={() => history.replace('datePage')}
         />

--- a/src/app/(reservation)/reserve/[id]/page.tsx
+++ b/src/app/(reservation)/reserve/[id]/page.tsx
@@ -8,6 +8,7 @@ import FormFunnel from '@/components/features/reserve/FormFunnel';
 import TimeFunnel from '@/components/features/reserve/TimeFunnel';
 import { STORAGE_KEY } from '@/constants/StorageKey';
 import { useHospitalName } from '@/hooks/map/useHospitalName';
+import { ReservationData } from '@/types/context';
 
 interface Params {
   params: {
@@ -17,9 +18,9 @@ interface Params {
 
 const ReservePage = ({ params }: Params) => {
   const funnel = useFunnel<{
-    datePage: any;
-    timePage: any;
-    submitPage: any;
+    datePage: ReservationData;
+    timePage: ReservationData;
+    submitPage: ReservationData;
   }>({
     id: 'my-reservation',
     initial: {

--- a/src/components/features/reserve/CalendarFunnel.tsx
+++ b/src/components/features/reserve/CalendarFunnel.tsx
@@ -69,7 +69,9 @@ const CalendarFunnel = ({ onNext }: Props) => {
         />
       </CardContent>
       <CardFooter className='mt-auto flex justify-evenly'>
-        <Button onClick={handleClick}>다음으로</Button>
+        <Button onClick={handleClick} size='move'>
+          다음으로
+        </Button>
       </CardFooter>
     </CardContainer>
   );

--- a/src/components/features/reserve/CalendarFunnel.tsx
+++ b/src/components/features/reserve/CalendarFunnel.tsx
@@ -68,7 +68,7 @@ const CalendarFunnel = ({ onNext }: Props) => {
           disabled={(date) => date < new Date()}
         />
       </CardContent>
-      <CardFooter className='mt-auto flex justify-evenly'>
+      <CardFooter className='absolute bottom-0 left-0 flex w-full justify-evenly px-12'>
         <Button onClick={handleClick} size='move'>
           다음으로
         </Button>

--- a/src/components/features/reserve/CalendarFunnel.tsx
+++ b/src/components/features/reserve/CalendarFunnel.tsx
@@ -44,9 +44,11 @@ const CalendarFunnel = ({ onNext }: Props) => {
       <CardHeaderContainer>
         원하는 예약 날짜를 선택해주세요.
       </CardHeaderContainer>
-      <Text size='lg' align='center' color='gray03'>
-        {getCalendarDate(date)}
-      </Text>
+      <div className='min-h-[30px]'>
+        <Text size='lg' align='center' color='gray03'>
+          {getCalendarDate(date)}
+        </Text>
+      </div>
       <CardContent className='my-5 flex flex-col items-center justify-center'>
         <Calendar
           mode='single'

--- a/src/components/features/reserve/FormFunnel.tsx
+++ b/src/components/features/reserve/FormFunnel.tsx
@@ -78,7 +78,7 @@ const FormFunnel = ({ name, id, onPrev }: Props) => {
   return (
     <CardContainer>
       <CardHeaderContainer>방문 사유를 입력해주세요.</CardHeaderContainer>
-      <CardContent className='my-5 flex h-3/5 flex-col items-start justify-center gap-5'>
+      <CardContent className='mt-16 flex h-3/5 flex-col items-start justify-center gap-5'>
         <Card className='flex w-full flex-col gap-3 px-10 py-7 shadow-none'>
           {reservationInfo.map((info) => (
             <div className='flex flex-col gap-2' key={crypto.randomUUID()}>

--- a/src/components/features/reserve/FormFunnel.tsx
+++ b/src/components/features/reserve/FormFunnel.tsx
@@ -8,6 +8,7 @@ import CardHeaderContainer from '@/components/layout/CardHeaderContainer';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
+import Text from '@/components/ui/Text';
 import { Textarea } from '@/components/ui/textarea';
 import { PATH } from '@/constants/routerPath';
 import { insertReservationInfo } from '@/utils/api/reservation';
@@ -81,8 +82,8 @@ const FormFunnel = ({ name, id, onPrev }: Props) => {
         <Card className='flex w-full flex-col gap-3 px-10 py-7 shadow-none'>
           {reservationInfo.map((info) => (
             <div className='flex flex-col gap-2' key={crypto.randomUUID()}>
-              <p className='font-bold text-gray04'>{info.title}</p>
-              <p className='text-gray04'>{info.value}</p>
+              <Text color='gray04'>{info.title}</Text>
+              <Text color='gray04'>{info.value}</Text>
             </div>
           ))}
         </Card>
@@ -107,7 +108,7 @@ const FormFunnel = ({ name, id, onPrev }: Props) => {
           </label>
         </div>
       </CardContent>
-      <CardFooter className='mt-10 flex gap-5'>
+      <CardFooter className='absolute bottom-0 left-0 flex w-full justify-evenly gap-5 px-12'>
         <Button onClick={() => onPrev()} size='move' variant='secondary'>
           이전으로
         </Button>

--- a/src/components/features/reserve/FormFunnel.tsx
+++ b/src/components/features/reserve/FormFunnel.tsx
@@ -107,9 +107,13 @@ const FormFunnel = ({ name, id, onPrev }: Props) => {
           </label>
         </div>
       </CardContent>
-      <CardFooter className='mt-10 flex justify-evenly'>
-        <Button onClick={() => onPrev()}>이전으로</Button>
-        <Button onClick={handleSubmit}>예약 완료하기</Button>
+      <CardFooter className='mt-10 flex gap-5'>
+        <Button onClick={() => onPrev()} size='move' variant='secondary'>
+          이전으로
+        </Button>
+        <Button onClick={handleSubmit} size='move'>
+          예약 완료하기
+        </Button>
       </CardFooter>
     </CardContainer>
   );

--- a/src/components/features/reserve/FormFunnel.tsx
+++ b/src/components/features/reserve/FormFunnel.tsx
@@ -82,7 +82,9 @@ const FormFunnel = ({ name, id, onPrev }: Props) => {
         <Card className='flex w-full flex-col gap-3 px-10 py-7 shadow-none'>
           {reservationInfo.map((info) => (
             <div className='flex flex-col gap-2' key={crypto.randomUUID()}>
-              <Text color='gray04'>{info.title}</Text>
+              <Text color='gray04' isBold>
+                {info.title}
+              </Text>
               <Text color='gray04'>{info.value}</Text>
             </div>
           ))}

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -94,8 +94,12 @@ const TimeFunnel = ({ operationTime, onNext, onPrev }: Props) => {
         </TimeButtonContainer>
       </CardContent>
       <CardFooter className='mt-16 flex w-full justify-evenly gap-5'>
-        <Button onClick={() => onPrev()}>이전으로</Button>
-        <Button onClick={handleClick}>다음으로</Button>
+        <Button onClick={() => onPrev()} size='move' variant='secondary'>
+          이전으로
+        </Button>
+        <Button onClick={handleClick} size='move'>
+          다음으로
+        </Button>
       </CardFooter>
     </CardContainer>
   );

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -69,7 +69,7 @@ const TimeFunnel = ({ operationTime, onNext, onPrev }: Props) => {
       <CardHeaderContainer>
         원하는 예약 시간을 선택해주세요.
       </CardHeaderContainer>
-      <CardContent className='mt-10 flex h-fit flex-col items-center justify-center gap-10'>
+      <CardContent className='mt-10 flex h-fit flex-col items-center justify-center gap-20'>
         {morning.length > 0 && (
           <TimeButtonContainer timeZone='오전'>
             {morning.map((morningTime) => (

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import CardContainer from '@/components/layout/CardContainer';
 import CardHeaderContainer from '@/components/layout/CardHeaderContainer';
@@ -12,9 +12,11 @@ import {
   getLocalStorage,
   updateLocalStorage,
 } from '@/utils/func/getLocalStorage';
+import { supabase } from '@/utils/supabase/supabase';
 
 interface Props {
   operationTime: { [key: string]: { open: string; close: string } };
+  id: string;
   onNext: () => void;
   onPrev: () => void;
 }
@@ -29,9 +31,21 @@ const dayOfWeek: { [key: string]: string } = {
   Sun: 'Sunday',
 };
 
-const TimeFunnel = ({ operationTime, onNext, onPrev }: Props) => {
+const TimeFunnel = ({ operationTime, id, onNext, onPrev }: Props) => {
   const { date, time: storageTime } = getLocalStorage();
   const [time, setTime] = useState<string>(storageTime || '');
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await supabase
+        .from('reservations')
+        .select('time')
+        .eq('hospital_id', id)
+        .eq('date', date);
+    };
+
+    fetchData();
+  }, []);
 
   const handleTimeButton = (time: string) => {
     setTime(time);

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -68,30 +68,34 @@ const TimeFunnel = ({ operationTime, onNext, onPrev }: Props) => {
         원하는 예약 시간을 선택해주세요.
       </CardHeaderContainer>
       <CardContent className='mt-10 flex h-fit flex-col items-center justify-center gap-10'>
-        <TimeButtonContainer timeZone='오전'>
-          {morning.map((morningTime) => (
-            <Button
-              key={crypto.randomUUID()}
-              variant={time === morningTime ? 'default' : 'time'}
-              size='time'
-              onClick={() => handleTimeButton(morningTime)}
-            >
-              {morningTime}
-            </Button>
-          ))}
-        </TimeButtonContainer>
-        <TimeButtonContainer timeZone='오후'>
-          {afternoon.map((afternoonTime) => (
-            <Button
-              key={crypto.randomUUID()}
-              variant={time == afternoonTime ? 'default' : 'time'}
-              size='time'
-              onClick={() => handleTimeButton(afternoonTime)}
-            >
-              {afternoonTime}
-            </Button>
-          ))}
-        </TimeButtonContainer>
+        {morning.length > 0 && (
+          <TimeButtonContainer timeZone='오전'>
+            {morning.map((morningTime) => (
+              <Button
+                key={crypto.randomUUID()}
+                variant={time === morningTime ? 'default' : 'time'}
+                size='time'
+                onClick={() => handleTimeButton(morningTime)}
+              >
+                {morningTime}
+              </Button>
+            ))}
+          </TimeButtonContainer>
+        )}
+        {afternoon.length > 0 && (
+          <TimeButtonContainer timeZone='오후'>
+            {afternoon.map((afternoonTime) => (
+              <Button
+                key={crypto.randomUUID()}
+                variant={time == afternoonTime ? 'default' : 'time'}
+                size='time'
+                onClick={() => handleTimeButton(afternoonTime)}
+              >
+                {afternoonTime}
+              </Button>
+            ))}
+          </TimeButtonContainer>
+        )}
       </CardContent>
       <CardFooter className='absolute bottom-0 left-0 flex w-full justify-evenly gap-5 px-12'>
         <Button onClick={() => onPrev()} size='move' variant='secondary'>

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -93,7 +93,7 @@ const TimeFunnel = ({ operationTime, onNext, onPrev }: Props) => {
           ))}
         </TimeButtonContainer>
       </CardContent>
-      <CardFooter className='mt-16 flex w-full justify-evenly gap-5'>
+      <CardFooter className='absolute bottom-0 left-0 flex w-full justify-evenly gap-5 px-12'>
         <Button onClick={() => onPrev()} size='move' variant='secondary'>
           이전으로
         </Button>

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -46,8 +46,10 @@ const TimeFunnel = ({ operationTime, onNext, onPrev }: Props) => {
     return (
       <CardContainer>
         <CardHeaderContainer>예약 가능한 시간이 없습니다</CardHeaderContainer>
-        <CardFooter className='mt-16 flex w-full justify-evenly gap-5'>
-          <Button onClick={() => onPrev()}>이전으로</Button>
+        <CardFooter className='absolute bottom-0 left-0 flex w-full justify-evenly gap-5 px-12'>
+          <Button onClick={() => onPrev()} size='move' variant='secondary'>
+            이전으로
+          </Button>
         </CardFooter>
       </CardContainer>
     );

--- a/src/components/layout/CardContainer.tsx
+++ b/src/components/layout/CardContainer.tsx
@@ -3,7 +3,7 @@ import { Card } from '../ui/card';
 const CardContainer = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className='flex max-h-fit min-h-screen w-full justify-center bg-gray02 py-10'>
-      <Card className='h-[700px] min-h-fit w-[650px] rounded-lg p-6 shadow-lg'>
+      <Card className='relative h-[700px] min-h-fit w-[650px] rounded-lg p-6 shadow-lg'>
         {children}
       </Card>
     </div>

--- a/src/components/layout/CardContainer.tsx
+++ b/src/components/layout/CardContainer.tsx
@@ -2,8 +2,8 @@ import { Card } from '../ui/card';
 
 const CardContainer = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className='flex h-screen w-full justify-center bg-gray02 pt-10'>
-      <Card className='max-h-fit min-h-[600px] w-[650px] rounded-lg p-6 shadow-lg'>
+    <div className='flex max-h-fit min-h-screen w-full justify-center bg-gray02 py-10'>
+      <Card className='h-[700px] min-h-fit w-[650px] rounded-lg p-6 shadow-lg'>
         {children}
       </Card>
     </div>

--- a/src/components/layout/TimeButtonContainer.tsx
+++ b/src/components/layout/TimeButtonContainer.tsx
@@ -1,3 +1,5 @@
+import Text from '../ui/Text';
+
 interface Props {
   children: React.ReactNode;
   timeZone: string;
@@ -5,9 +7,13 @@ interface Props {
 
 const TimeButtonContainer = ({ children, timeZone }: Props) => {
   return (
-    <div className='flex flex-col items-start gap-2'>
-      <p className='font-bold'>{timeZone}</p>
-      <div className='mx-auto grid max-w-md gap-4 [grid-template-columns:repeat(auto-fit,minmax(100px,1fr))]'>
+    <div className='flex w-full flex-col items-center gap-2'>
+      <div className='grid w-full max-w-lg gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5'>
+        <div className='col-span-full ml-2'>
+          <Text isBold align='left' size='lg'>
+            {timeZone}
+          </Text>
+        </div>
         {children}
       </div>
     </div>

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -42,6 +42,7 @@ const Text = ({
     gray01: 'text-gray01',
     gray02: 'text-gray02',
     gray03: 'text-gray03',
+    gray04: 'text-gray04',
     red: 'text-red',
     'deep-blue': 'text-deep-blue',
   };

--- a/src/components/ui/Title.tsx
+++ b/src/components/ui/Title.tsx
@@ -29,6 +29,7 @@ export interface TitleProps {
     | 'gray01'
     | 'gray02'
     | 'gray03'
+    | 'gray04'
     | 'red'
     | 'deep-blue';
 }
@@ -63,6 +64,7 @@ const Title = ({
     gray01: 'text-gray01',
     gray02: 'text-gray02',
     gray03: 'text-gray03',
+    gray04: 'text-gray04',
     red: 'text-red',
     'deep-blue': 'text-deep-blue',
   };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -15,8 +15,7 @@ const buttonVariants = cva(
         outline:
           'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         time: 'border border-main bg-background hover:bg-accent hover:text-accent-foreground hover:bg-main',
-        secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-gray03',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
@@ -26,6 +25,7 @@ const buttonVariants = cva(
         lg: 'h-10 rounded-md px-8',
         icon: 'h-9 w-9',
         time: 'px-5 py-2 text-base',
+        move: 'h-9 px-4 w-1/2 py-6 text-lg',
       },
     },
     defaultVariants: {

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,5 @@
+export interface ReservationData {
+  date?: string;
+  time?: string;
+  memo?: string;
+}


### PR DESCRIPTION
## ✨ style(#59): 예약 페이지 스타일 정리

<br/>

## 🔎 작업 내용

- 예약 페이지 내에서 카드의 크기와 버튼의 스타일을 수정하고 고정하였습니다.

- 예약 시간이 없을 경우 오전/오후 글씨가 사라지도록 하였습니다.

- 시간 선택 페이지의 grid를 반응형으로 수정하였습니다.

  <br/>

## 🖼️ 작업 내용 미리보기


https://github.com/user-attachments/assets/a8d063c8-7ecb-43d9-a20c-130f919ae3a6



<br/>

## ⏰ 예상 리뷰 시간

5-10분

### ✔️ 이슈 닫기

Closes #59 
