### PR TITLE
[Feature]#74 og메타데이터 추가

### DIFF
--- a/src/app/(reservation)/hospital/[...id]/page.tsx
+++ b/src/app/(reservation)/hospital/[...id]/page.tsx
@@ -21,6 +21,10 @@ export async function generateMetadata({
     return {
       title: hospitalData?.dutyName || '병원 정보',
       description: hospitalData?.dutyAddr || '병원 상세 정보',
+      openGraph: {
+        title: hospitalData?.dutyName || '병원 정보',
+        description: hospitalData?.dutyAddr || '병원 상세 정보',
+      },
     };
   } catch (error) {
     console.error('Error generating metadata:', error);


### PR DESCRIPTION
## ✨ feature(#74): 메타데이터 og 추가

<br/>

## 🔎 작업 내용

- 병원 상세 페이지 메타데이터 og추가
-  카카오 static map 이미지 주소를 받아서 og:image도 진행하려 했으나 카카오맵이 공식적으로 정적 이미지 URL API를 제공하지 않아서, 임의로 https://map2.daum.net/map/imageservice를 사용하면 가능할 것이라 생각했는데... 이 API의 주소 파라미터값이 일반 위도, 경도 값이 아니라 추가적인 좌표계 변환이 필요해서 이 기능은 나중에 가능하다면... 추가해보도록 하겠습니다.

  <br/>

## 🖼️ 작업 내용 미리보기

<img width="1463" alt="스크린샷 2025-03-25 오전 11 32 33" src="https://github.com/user-attachments/assets/7b13f749-64c7-476b-9a3d-269369cc1efc" />


<br/>

## 💬 리뷰 요구사항

> 없습니다.

## ⏰ 예상 리뷰 시간

1분

### ✔️ 이슈 닫기

Closes #74
