### PR TITLE
[Feature]#73 로그인 상태 관리하는 middleware 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
+    "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.1",
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.69.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@18.3.19)(react@18.3.1)
+      '@supabase/ssr':
+        specifier: ^0.6.1
+        version: 0.6.1(@supabase/supabase-js@2.49.1)
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.49.1
@@ -655,6 +658,11 @@ packages:
   '@supabase/realtime-js@2.11.2':
     resolution: {integrity: sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==}
 
+  '@supabase/ssr@0.6.1':
+    resolution: {integrity: sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
   '@supabase/storage-js@2.7.1':
     resolution: {integrity: sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==}
 
@@ -1030,6 +1038,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3047,6 +3059,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@supabase/ssr@0.6.1(@supabase/supabase-js@2.49.1)':
+    dependencies:
+      '@supabase/supabase-js': 2.49.1
+      cookie: 1.0.2
+
   '@supabase/storage-js@2.7.1':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -3456,6 +3473,8 @@ snapshots:
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
+
+  cookie@1.0.2: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from 'next/server';
+import { updateSession } from '@/utils/supabase/middleware';
+
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -12,9 +12,7 @@ import {
   getLocalStorage,
   updateLocalStorage,
 } from '@/utils/func/getLocalStorage';
-import { createClient } from '@/utils/supabase/supabaseClient';
-
-const supabase = createClient();
+import { supabase } from '@/utils/supabase/supabaseClient';
 
 interface Props {
   operationTime: { [key: string]: { open: string; close: string } };

--- a/src/components/features/reserve/TimeFunnel.tsx
+++ b/src/components/features/reserve/TimeFunnel.tsx
@@ -12,7 +12,9 @@ import {
   getLocalStorage,
   updateLocalStorage,
 } from '@/utils/func/getLocalStorage';
-import { supabase } from '@/utils/supabase/supabase';
+import { createClient } from '@/utils/supabase/supabaseClient';
+
+const supabase = createClient();
 
 interface Props {
   operationTime: { [key: string]: { open: string; close: string } };

--- a/src/utils/api/auth.ts
+++ b/src/utils/api/auth.ts
@@ -1,4 +1,6 @@
-import { supabase } from '../supabase/supabase';
+import { createClient } from '../supabase/supabaseClient';
+
+const supabase = createClient();
 
 interface FormData {
   email: string;

--- a/src/utils/api/auth.ts
+++ b/src/utils/api/auth.ts
@@ -1,6 +1,4 @@
-import { createClient } from '../supabase/supabaseClient';
-
-const supabase = createClient();
+import { supabase } from '../supabase/supabaseClient';
 
 interface FormData {
   email: string;

--- a/src/utils/api/hospitalDetail.ts
+++ b/src/utils/api/hospitalDetail.ts
@@ -1,8 +1,6 @@
 import { TABLE } from '@/constants/supabaseTables';
 import { Location } from '@/types/map';
-import { createClient } from '../supabase/supabaseClient';
-
-const supabase = createClient();
+import { supabase } from '../supabase/supabaseClient';
 
 /**
  * 병원 상세 정보 조회를 위한 기본 URL 생성 함수

--- a/src/utils/api/hospitalDetail.ts
+++ b/src/utils/api/hospitalDetail.ts
@@ -1,6 +1,8 @@
 import { TABLE } from '@/constants/supabaseTables';
 import { Location } from '@/types/map';
-import { supabase } from '../supabase/supabase';
+import { createClient } from '../supabase/supabaseClient';
+
+const supabase = createClient();
 
 /**
  * 병원 상세 정보 조회를 위한 기본 URL 생성 함수
@@ -91,7 +93,7 @@ export default hospitalDetail;
  */
 export const getHospitalDetailLocation = async (id: string) => {
   try {
-    let hospitalLocation: Location = { lat: 0, lng: 0 };
+    let hospitalLocation: Omit<Location, 'id' | 'name'> = { lat: 0, lng: 0 };
 
     const { data, error } = await supabase
       .from(TABLE.HOSPITALS)

--- a/src/utils/api/hospitals.ts
+++ b/src/utils/api/hospitals.ts
@@ -1,9 +1,7 @@
 import { TABLE } from '@/constants/supabaseTables';
 import { Location } from '@/types/map';
 import { Tables } from '@/types/supabase';
-import { createClient } from '../supabase/supabaseClient';
-
-const supabase = createClient();
+import { supabase } from '../supabase/supabaseClient';
 
 /**
  * 모든 병원의 위치(위도, 경도, 이름, id)를 반환하는 함수

--- a/src/utils/api/hospitals.ts
+++ b/src/utils/api/hospitals.ts
@@ -1,7 +1,9 @@
 import { TABLE } from '@/constants/supabaseTables';
 import { Location } from '@/types/map';
 import { Tables } from '@/types/supabase';
-import { supabase } from '../supabase/supabase';
+import { createClient } from '../supabase/supabaseClient';
+
+const supabase = createClient();
 
 /**
  * 모든 병원의 위치(위도, 경도, 이름, id)를 반환하는 함수

--- a/src/utils/api/reservation.ts
+++ b/src/utils/api/reservation.ts
@@ -1,8 +1,6 @@
 import { COLUMN, TABLE } from '@/constants/supabaseTables';
 import { Tables } from '@/types/supabase';
-import { createClient } from '../supabase/supabaseClient';
-
-const supabase = createClient();
+import { supabase } from '../supabase/supabaseClient';
 
 const testId: string = '0d6511b9-926b-443f-9828-39e5f302e1e4'; // zustand 또는 로그인 세션에서 받아올 현재 로그인 된 유저 아이디 값
 

--- a/src/utils/api/reservation.ts
+++ b/src/utils/api/reservation.ts
@@ -1,6 +1,8 @@
 import { COLUMN, TABLE } from '@/constants/supabaseTables';
 import { Tables } from '@/types/supabase';
-import { supabase } from '../supabase/supabase';
+import { createClient } from '../supabase/supabaseClient';
+
+const supabase = createClient();
 
 const testId: string = '0d6511b9-926b-443f-9828-39e5f302e1e4'; // zustand 또는 로그인 세션에서 받아올 현재 로그인 된 유저 아이디 값
 

--- a/src/utils/api/userProfile.ts
+++ b/src/utils/api/userProfile.ts
@@ -1,7 +1,9 @@
 // import { Session } from '@supabase/supabase-js';
 import { COLUMN, TABLE } from '@/constants/supabaseTables';
 import { Tables } from '@/types/supabase';
-import { supabase } from '../supabase/supabase';
+import { createClient } from '../supabase/supabaseClient';
+
+const supabase = createClient();
 
 const testId: string = '0d6511b9-926b-443f-9828-39e5f302e1e4'; // zustand 또는 로그인 세션에서 받아올 현재 로그인 된 유저 아이디 값
 

--- a/src/utils/api/userProfile.ts
+++ b/src/utils/api/userProfile.ts
@@ -1,9 +1,7 @@
 // import { Session } from '@supabase/supabase-js';
 import { COLUMN, TABLE } from '@/constants/supabaseTables';
 import { Tables } from '@/types/supabase';
-import { createClient } from '../supabase/supabaseClient';
-
-const supabase = createClient();
+import { supabase } from '../supabase/supabaseClient';
 
 const testId: string = '0d6511b9-926b-443f-9828-39e5f302e1e4'; // zustand 또는 로그인 세션에서 받아올 현재 로그인 된 유저 아이디 값
 

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -1,0 +1,56 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+import { PATH } from '@/constants/routerPath';
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        // 사용자의 쿠키에서 로그인 세션을 가져옴
+        getAll() {
+          return request.cookies.getAll();
+        },
+        //새로운 세션 정보를 쿠키에 저장 (로그인 상태 유지)
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    supabaseResponse.headers.set('x-user-info', JSON.stringify(user));
+  }
+
+  //로그인되지 않은 사용자를 로그인 페이지로 보내는 로직
+  if (
+    !user &&
+    !request.nextUrl.pathname.startsWith(PATH.LOGIN) &&
+    !request.nextUrl.pathname.startsWith(PATH.SIGNUP) &&
+    !request.nextUrl.pathname.startsWith(PATH.HOME)
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = PATH.LOGIN;
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}

--- a/src/utils/supabase/supabase.ts
+++ b/src/utils/supabase/supabase.ts
@@ -1,7 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-import { Database } from '@/types/supabase';
-
-export const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-);

--- a/src/utils/supabase/supabaseClient.ts
+++ b/src/utils/supabase/supabaseClient.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr';
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}

--- a/src/utils/supabase/supabaseClient.ts
+++ b/src/utils/supabase/supabaseClient.ts
@@ -1,8 +1,6 @@
 import { createBrowserClient } from '@supabase/ssr';
 
-export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  );
-}
+export const supabase = createBrowserClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);

--- a/src/utils/supabase/supabaseServer.ts
+++ b/src/utils/supabase/supabaseServer.ts
@@ -1,0 +1,23 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export function createClient() {
+  const cookieStore = cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+}


### PR DESCRIPTION
## ✨ feature(#73):  로그인 상태 관리하는 middleware 추가

<br/>

## 🔎 작업 내용
✅ supabase 클라이언트를 server용과 client용으로 분리하였습니다.
middleware을 이용하기 위해 분리하였습니다.
✅ 사용자가 로그인하지 않았을 때 메인 서비스를 이용하지 못하게 막기 위해 middleware을 이용했습니다.
문제는.. 아직 로그인 상태를 제대로 확인할 수 없어서 코드가 잘 동작하는지 확인할 수가 없습니다.

➕ zustand로 로그인 여부와 사용자 정보를 관리하는 로직을 짜고 싶었는데, 로그인/회원가입 로직에 대해 자세히 모르다보니 짤 수가 없더라고요.. 하하 이 부분은 다시 현식님께 부탁드렸습니다.

⭐️⭐️ supabase ssr 라이브러리를 설치하였습니다. pull 받으시고` pnpm install` 해주시면 감사하겠습니다.

<br/>

## 🖼️ 작업 내용 미리보기
❌

<br/>

## 💬 리뷰 요구사항


## ⏰ 예상 리뷰 시간
5분

### ✔️ 이슈 닫기

Closes #73
