### PR TITLE
[Style]#77 마이페이지-병원측 환자 예약 목록 UI 마크업

### DIFF
--- a/src/app/(auth)/mypage/reservations/page.tsx
+++ b/src/app/(auth)/mypage/reservations/page.tsx
@@ -1,13 +1,20 @@
+import ReservationsPage from '@/components/features/mypage/hospitalReservations/Reservations';
 import MainContentsContainer from '@/components/features/mypage/MainContentsContainer';
 import MainContentsTitleBox from '@/components/features/mypage/MainContentsTitleBox';
 import ReservationList from '@/components/features/mypage/myReservations/ReservationList';
 
 const ReserveListPage = () => {
   return (
-    <MainContentsContainer>
-      <MainContentsTitleBox title='내 예약 목록' />
-      <ReservationList />
-    </MainContentsContainer>
+    <>
+      {true ? (
+        <MainContentsContainer>
+          <MainContentsTitleBox title='내 예약 목록' />
+          <ReservationList />
+        </MainContentsContainer>
+      ) : (
+        <ReservationsPage />
+      )}
+    </>
   );
 };
 

--- a/src/components/features/mypage/hospitalReservations/DateNavigation.tsx
+++ b/src/components/features/mypage/hospitalReservations/DateNavigation.tsx
@@ -1,0 +1,47 @@
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
+import Text from '@/components/ui/Text';
+import { APPOINTMENT_STYLES } from '@/constants/styles';
+
+interface DateNavigationProps {
+  previousDate: string;
+  currentDate: string;
+  nextDate: string;
+  onPreviousClick: () => void;
+  onNextClick: () => void;
+}
+
+const DateNavigation = ({
+  previousDate,
+  currentDate,
+  nextDate,
+  onPreviousClick,
+  onNextClick,
+}: DateNavigationProps) => {
+  return (
+    <div className={APPOINTMENT_STYLES.dateNavContainer}>
+      <div
+        className={APPOINTMENT_STYLES.dateNavItem}
+        onClick={onPreviousClick}
+        role='button'
+      >
+        <IoIosArrowBack size={24} />
+        <Text size='xl'>{previousDate}</Text>
+      </div>
+      <div className='flex items-center'>
+        <Text size='xl' color='deep-blue' isBold={true}>
+          {currentDate}
+        </Text>
+      </div>
+      <div
+        className={APPOINTMENT_STYLES.dateNavItem}
+        onClick={onNextClick}
+        role='button'
+      >
+        <Text size='xl'>{nextDate}</Text>
+        <IoIosArrowForward size={24} />
+      </div>
+    </div>
+  );
+};
+
+export default DateNavigation;

--- a/src/components/features/mypage/hospitalReservations/ReservationBanner.tsx
+++ b/src/components/features/mypage/hospitalReservations/ReservationBanner.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button';
+import Text from '@/components/ui/Text';
+import Title from '@/components/ui/Title';
+import BannerContainer from '../myReserveDetail/banner/BannerContainer';
+
+interface ReservationBannerProps {
+  hospitalName: string;
+  patientCount: number;
+  currentDate: string;
+}
+
+const ReservationBanner = ({
+  hospitalName,
+  patientCount,
+  currentDate,
+}: ReservationBannerProps) => {
+  return (
+    <BannerContainer>
+      <div className='flex flex-1'>
+        <div className='flex w-full flex-row items-center justify-between'>
+          <div className='flex flex-col gap-5'>
+            <Title tag='h1' size='lg' align='left' color='deep-blue'>
+              {hospitalName}
+            </Title>
+            <Text size='lg' align='left' color='black02'>
+              오늘 방문 예정 환자: {patientCount}명
+            </Text>
+          </div>
+          <Button className='h-[44px] w-[200px] rounded-[10px] bg-deep-blue text-lg'>
+            {currentDate}
+          </Button>
+        </div>
+      </div>
+    </BannerContainer>
+  );
+};
+
+export default ReservationBanner;

--- a/src/components/features/mypage/hospitalReservations/ReservationTable.tsx
+++ b/src/components/features/mypage/hospitalReservations/ReservationTable.tsx
@@ -14,16 +14,17 @@ interface ReservationTableProps {
 }
 
 const ReservationTable = ({ reservations }: ReservationTableProps) => {
+  const thData = ['시간', '환자명', '연락처', '증상', '상태'];
   return (
     <div className={APPOINTMENT_STYLES.container}>
       <table className='w-full border-collapse'>
         <thead className={APPOINTMENT_STYLES.tableHeader}>
           <tr>
-            <th className={APPOINTMENT_STYLES.tableHeaderCell}>시간</th>
-            <th className={APPOINTMENT_STYLES.tableHeaderCell}>환자명</th>
-            <th className={APPOINTMENT_STYLES.tableHeaderCell}>연락처</th>
-            <th className={APPOINTMENT_STYLES.tableHeaderCell}>증상</th>
-            <th className={APPOINTMENT_STYLES.tableHeaderCell}>상태</th>
+            {thData.map((th, i) => (
+              <th key={i} className={APPOINTMENT_STYLES.tableHeaderCell}>
+                {th}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody className='divide-y divide-[#cccbc8] text-center'>

--- a/src/components/features/mypage/hospitalReservations/ReservationTable.tsx
+++ b/src/components/features/mypage/hospitalReservations/ReservationTable.tsx
@@ -1,0 +1,53 @@
+import { APPOINTMENT_STYLES } from '@/constants/styles';
+import StatusBadge from './StatusBadge';
+
+interface Reservation {
+  time: string;
+  name: string;
+  phone: string;
+  symptoms: string;
+  status: 'waiting' | 'confirmed';
+}
+
+interface ReservationTableProps {
+  reservations: Reservation[];
+}
+
+const ReservationTable = ({ reservations }: ReservationTableProps) => {
+  return (
+    <div className={APPOINTMENT_STYLES.container}>
+      <table className='w-full border-collapse'>
+        <thead className={APPOINTMENT_STYLES.tableHeader}>
+          <tr>
+            <th className={APPOINTMENT_STYLES.tableHeaderCell}>시간</th>
+            <th className={APPOINTMENT_STYLES.tableHeaderCell}>환자명</th>
+            <th className={APPOINTMENT_STYLES.tableHeaderCell}>연락처</th>
+            <th className={APPOINTMENT_STYLES.tableHeaderCell}>증상</th>
+            <th className={APPOINTMENT_STYLES.tableHeaderCell}>상태</th>
+          </tr>
+        </thead>
+        <tbody className='divide-y divide-[#cccbc8] text-center'>
+          {reservations.map((appointment, index) => (
+            <tr key={index} className={APPOINTMENT_STYLES.tableRow}>
+              <td className={APPOINTMENT_STYLES.tableCell}>
+                {appointment.time}
+              </td>
+              <td className={APPOINTMENT_STYLES.tableCell}>
+                {appointment.name}
+              </td>
+              <td className={APPOINTMENT_STYLES.tableCell}>
+                {appointment.phone}
+              </td>
+              <td className={`px-6 py-6`}>{appointment.symptoms}</td>
+              <td className={APPOINTMENT_STYLES.tableCell}>
+                <StatusBadge status={appointment.status} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ReservationTable;

--- a/src/components/features/mypage/hospitalReservations/Reservations.tsx
+++ b/src/components/features/mypage/hospitalReservations/Reservations.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useState } from 'react';
+import DateNavigation from './DateNavigation';
+import ReservationBanner from './ReservationBanner';
+import ReservationTable from './ReservationTable';
+
+const ReservationsPage = () => {
+  const [currentDate, setCurrentDate] = useState(new Date());
+
+  // 날짜 관련 함수들
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      weekday: 'short',
+    });
+  };
+
+  const formatShortDate = (date: Date) => {
+    return date.toLocaleDateString('ko-KR', {
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const getPreviousDay = () => {
+    const prevDate = new Date(currentDate);
+    prevDate.setDate(prevDate.getDate() - 1);
+    return prevDate;
+  };
+
+  const getNextDay = () => {
+    const nextDate = new Date(currentDate);
+    nextDate.setDate(nextDate.getDate() + 1);
+    return nextDate;
+  };
+
+  // 예약 데이터 (실제로는 API에서 가져올 것)
+  const reservations = [
+    {
+      time: '09:00',
+      name: '김땡땡',
+      phone: '010-1234-5678',
+      symptoms: '발열, 두통',
+      status: 'waiting' as const,
+    },
+    {
+      time: '10:30',
+      name: '이땡땡',
+      phone: '010-0000-0000',
+      symptoms: '소화불량',
+      status: 'confirmed' as const,
+    },
+  ];
+
+  return (
+    <div className='container mx-auto px-4 py-8'>
+      <ReservationBanner
+        hospitalName='서울통정형외과의원 잠실점'
+        patientCount={reservations.length}
+        currentDate={formatDate(currentDate)}
+      />
+
+      <div className='my-6'>
+        <DateNavigation
+          previousDate={formatShortDate(getPreviousDay())}
+          currentDate={formatShortDate(currentDate)}
+          nextDate={formatShortDate(getNextDay())}
+          onPreviousClick={() => setCurrentDate(getPreviousDay())}
+          onNextClick={() => setCurrentDate(getNextDay())}
+        />
+      </div>
+
+      <ReservationTable reservations={reservations} />
+    </div>
+  );
+};
+
+export default ReservationsPage;

--- a/src/components/features/mypage/hospitalReservations/Reservations.tsx
+++ b/src/components/features/mypage/hospitalReservations/Reservations.tsx
@@ -1,40 +1,17 @@
 'use client';
 import { useState } from 'react';
+import {
+  formatDate,
+  formatShortDate,
+  getNextDay,
+  getPreviousDay,
+} from '@/utils/func/formatDate';
 import DateNavigation from './DateNavigation';
 import ReservationBanner from './ReservationBanner';
 import ReservationTable from './ReservationTable';
 
 const ReservationsPage = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
-
-  // 날짜 관련 함수들
-  const formatDate = (date: Date) => {
-    return date.toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      weekday: 'short',
-    });
-  };
-
-  const formatShortDate = (date: Date) => {
-    return date.toLocaleDateString('ko-KR', {
-      month: 'long',
-      day: 'numeric',
-    });
-  };
-
-  const getPreviousDay = () => {
-    const prevDate = new Date(currentDate);
-    prevDate.setDate(prevDate.getDate() - 1);
-    return prevDate;
-  };
-
-  const getNextDay = () => {
-    const nextDate = new Date(currentDate);
-    nextDate.setDate(nextDate.getDate() + 1);
-    return nextDate;
-  };
 
   // 예약 데이터 (실제로는 API에서 가져올 것)
   const reservations = [
@@ -64,11 +41,11 @@ const ReservationsPage = () => {
 
       <div className='my-6'>
         <DateNavigation
-          previousDate={formatShortDate(getPreviousDay())}
+          previousDate={formatShortDate(getPreviousDay(currentDate))}
           currentDate={formatShortDate(currentDate)}
-          nextDate={formatShortDate(getNextDay())}
-          onPreviousClick={() => setCurrentDate(getPreviousDay())}
-          onNextClick={() => setCurrentDate(getNextDay())}
+          nextDate={formatShortDate(getNextDay(currentDate))}
+          onPreviousClick={() => setCurrentDate(getPreviousDay(currentDate))}
+          onNextClick={() => setCurrentDate(getNextDay(currentDate))}
         />
       </div>
 

--- a/src/components/features/mypage/hospitalReservations/StatusBadge.tsx
+++ b/src/components/features/mypage/hospitalReservations/StatusBadge.tsx
@@ -1,0 +1,20 @@
+import { APPOINTMENT_STYLES } from '@/constants/styles';
+
+interface StatusBadgeProps {
+  status: 'waiting' | 'confirmed';
+}
+
+const StatusBadge = ({ status }: StatusBadgeProps) => {
+  const badgeStyle =
+    status === 'waiting'
+      ? APPOINTMENT_STYLES.statusWaiting
+      : APPOINTMENT_STYLES.statusConfirmed;
+
+  return (
+    <span className={badgeStyle}>
+      {status === 'waiting' ? '대기중' : '확정'}
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,0 +1,14 @@
+export const APPOINTMENT_STYLES = {
+  container: 'overflow-hidden rounded-lg border-2 border-gray03 text-xl',
+  tableHeader: 'rounded-lg bg-deep-blue',
+  tableHeaderCell: 'border-b-2 px-6 py-6 text-center font-semibold text-white',
+  tableRow: 'hover:bg-gray-50',
+  tableCell: 'whitespace-nowrap px-6 py-6',
+  statusWaiting:
+    'inline-flex rounded-full bg-gray03 px-10 py-2 text-xl font-medium text-black02',
+  statusConfirmed:
+    'inline-flex items-center justify-center rounded-full bg-main px-10 py-2 text-xl font-medium text-white',
+  dateNavContainer:
+    'flex min-h-20 flex-wrap justify-evenly rounded-[15px] border-2 border-gray03 p-5 leading-6',
+  dateNavItem: 'flex items-center gap-4',
+};

--- a/src/utils/func/formatDate.ts
+++ b/src/utils/func/formatDate.ts
@@ -1,0 +1,28 @@
+// 날짜 관련 함수들
+export const formatDate = (date: Date) => {
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  });
+};
+
+export const formatShortDate = (date: Date) => {
+  return date.toLocaleDateString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
+export const getPreviousDay = (currentDate: Date) => {
+  const prevDate = new Date(currentDate);
+  prevDate.setDate(prevDate.getDate() - 1);
+  return prevDate;
+};
+
+export const getNextDay = (currentDate: Date) => {
+  const nextDate = new Date(currentDate);
+  nextDate.setDate(nextDate.getDate() + 1);
+  return nextDate;
+};


### PR DESCRIPTION
## ✨ feature(#77): 병원측 환자 예약 목록 마크업

<br/>

## 🔎 작업 내용

- 병원측 마이페이지 환자 예약 목록 마크업
- true로 되어있는 삼항연산자와 왼쪽nav메뉴는 추후 병원/일반 별 분리값을 생성한 뒤에 추후변경
- 좌측/우측 버튼 클릭 시 이전/이후 날짜가 뜨도록 추가하였습니다
- 현재 날짜가 뜨도록 반영하였습니다.

  <br/>

## 🖼️ 작업 내용 미리보기

<img width="1466" alt="스크린샷 2025-03-25 오후 10 11 19" src="https://github.com/user-attachments/assets/4f97117e-2be3-47c0-b51b-02eff26da464" />


<br/>

## 💬 리뷰 요구사항

> 없습니다.

## ⏰ 예상 리뷰 시간

15분

### ✔️ 이슈 닫기

Closes #77
